### PR TITLE
Run API queries concurrently

### DIFF
--- a/benchmark_request.sh
+++ b/benchmark_request.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This script benchmarks the runtime of a specified curl request.
+#
+# The script performs the following steps:
+# 1. Repeats the curl request a specified number of times.
+# 2. Measures the time taken for each request using /usr/bin/time.
+# 3. Accumulates the time taken for each request.
+# 4. Computes the average runtime of the requests.
+#
+# Usage:
+# Save this script in a file, e.g., benchmark_curl.sh, make it executable using:
+# chmod +x benchmark_curl.sh
+#
+# Run it with:
+# ./benchmark_curl.sh
+#
+# Note:
+# - Make sure `bc` is installed to handle floating-point arithmetic.
+# - Ensure the URL and NUM_REQUESTS variables are correctly set to meet your requirements.
+# - This script assumes the server at `http://localhost:8000` is running and accessible.
+#
+# Variables:
+# URL - The URL to which the curl requests are made.
+# NUM_REQUESTS - The number of repeated curl requests to measure for calculating the average runtime.
+
+# URL and options for the curl command
+URL="http://localhost:8000/search?bbox=-180.0,-90.0,180.0,90&text=dem&datetime=2024-01-01T00:00:00Z/.."
+
+# Number of requests to average
+NUM_REQUESTS=10
+
+# Initialize the sum of all runtimes
+total_time=0
+
+# Function to perform curl and measure time
+measure_time() {
+    # Use /usr/bin/time to get real time (--format=': %e' ensures we only capture the time in seconds)
+    result=$(/usr/bin/time -f "%e" curl -s -o /dev/null -X GET "${URL}" 2>&1)
+    echo $result
+}
+
+# Loop to perform multiple requests
+for ((i=1; i<=NUM_REQUESTS; i++))
+do
+    runtime=$(measure_time)
+    echo "Request $i: ${runtime} seconds"
+    total_time=$(echo "$total_time + $runtime" | bc)
+done
+
+# Calculate average time
+average_time=$(echo "scale=2; $total_time / $NUM_REQUESTS" | bc)
+echo "Average runtime for $NUM_REQUESTS requests: ${average_time} seconds"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - ./src/server:/app
     environment:
       - PYTHONUNBUFFERED=1
-      - FEDERATED_STAC_API_URLS=https://stac.maap-project.org/,https://dev.asdi-catalog.org/,https://cmr.earthdata.nasa.gov/stac/LPCLOUD/
+      - FEDERATED_STAC_API_URLS=https://stac.maap-project.org/,https://openveda.cloud/api/stac/,https://catalogue.dataspace.copernicus.eu/stac
       # - FEDERATED_CMR_URLS=https://cmr.earthdata.nasa.gov/search/
 
   client:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./src/server:/app
+      - ./src/server/app:/app/app
     environment:
       - PYTHONUNBUFFERED=1
       - FEDERATED_STAC_API_URLS=https://stac.maap-project.org/,https://openveda.cloud/api/stac/,https://catalogue.dataspace.copernicus.eu/stac
@@ -24,4 +24,3 @@ services:
       - REACT_APP_API_URL=http://localhost:8000
     depends_on:
       - server
-

--- a/src/server/Dockerfile
+++ b/src/server/Dockerfile
@@ -4,9 +4,12 @@ WORKDIR /app
 
 RUN pip install poetry
 
-COPY ./pyproject.toml /app/
-COPY ./app /app/
+COPY pyproject.toml poetry.lock /app/
 
-RUN poetry install --no-root
+RUN poetry install --no-root --no-dev
+
+COPY . /app
+
+RUN poetry install
 
 CMD ["poetry", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/src/server/poetry.lock
+++ b/src/server/poetry.lock
@@ -3209,4 +3209,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "2392bebacf4318efcd9f0e9104c1904efbbab7fe3444352efd8922b5365bd4c1"
+content-hash = "74feeca3cc2daa450d77ba3ca3dbcce26b0d085c50d5e05076cec78575d9de5b"

--- a/src/server/poetry.lock
+++ b/src/server/poetry.lock
@@ -121,6 +121,20 @@ doc = ["doc8", "sphinx (>=7.0.0)", "sphinx-autobuild", "sphinx-autodoc-typehints
 test = ["dateparser (==1.*)", "pre-commit", "pytest", "pytest-cov", "pytest-mock", "pytz (==2021.1)", "simplejson (==3.*)"]
 
 [[package]]
+name = "asgi-lifespan"
+version = "2.1.0"
+description = "Programmatic startup/shutdown of ASGI apps."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "asgi-lifespan-2.1.0.tar.gz", hash = "sha256:5e2effaf0bfe39829cf2d64e7ecc47c7d86d676a6599f7afba378c31f5e3a308"},
+    {file = "asgi_lifespan-2.1.0-py3-none-any.whl", hash = "sha256:ed840706680e28428c01e14afb3875d7d76d3206f3d5b2f2294e059b5c23804f"},
+]
+
+[package.dependencies]
+sniffio = "*"
+
+[[package]]
 name = "asttokens"
 version = "2.4.1"
 description = "Annotate AST trees with source code positions"
@@ -2009,6 +2023,24 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.23.8"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2"},
+    {file = "pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0,<9"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
+
+[[package]]
 name = "pytest-mock"
 version = "3.14.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
@@ -3177,4 +3209,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "c643109fcecbd81ba77c3fb640a2c2e0ee05222ef788fbeef27389991bf93881"
+content-hash = "2392bebacf4318efcd9f0e9104c1904efbbab7fe3444352efd8922b5365bd4c1"

--- a/src/server/pyproject.toml
+++ b/src/server/pyproject.toml
@@ -9,7 +9,6 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-fastapi = "^0.111.0"
 pystac-client = "^0.8.2"
 stac-fastapi-types = "^3.0.0a1"
 uvicorn = "^0.30.1"
@@ -18,6 +17,7 @@ pydantic-settings = "^2.3.4"
 black = "^24.4.2"
 httpx = "^0.27.0"
 python-cmr = "^0.11.0"
+fastapi = "^0.111.1"
 
 [tool.poetry.group.dev.dependencies]
 jupyterlab = "^4.2.3"

--- a/src/server/pyproject.toml
+++ b/src/server/pyproject.toml
@@ -27,6 +27,8 @@ pytest-mock = "^3.14.0"
 requests-mock = "^1.12.1"
 ruff = "^0.5.2"
 types-requests = "^2.32.0.20240712"
+pytest-asyncio = "^0.23.8"
+asgi-lifespan = "^2.1.0"
 
 [tool.isort]
 profile = "black"

--- a/src/server/tests/conftest.py
+++ b/src/server/tests/conftest.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 import requests_mock
 
@@ -111,3 +113,16 @@ def mock_apis():
             m.get(base_url, status_code=200, json=catalog_root_response)
 
         yield base_urls
+
+
+@pytest.fixture(scope="module")
+def executor():
+    """Fixture to provide a ThreadPoolExecutor instance."""
+    ex = ThreadPoolExecutor()
+    yield ex
+    ex.shutdown()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/src/server/tests/test_collection_search.py
+++ b/src/server/tests/test_collection_search.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import pytest
 from cmr import CMR_OPS
 
 from app.cmr_collection_search import CMRCollectionSearch
@@ -7,11 +8,13 @@ from app.collection_search import search_all
 from app.stac_api_collection_search import STACAPICollectionSearch
 
 
-def test_search_all(mock_apis):
-    actual_metadata = search_all(
+@pytest.mark.asyncio
+async def test_search_all(executor, mock_apis):
+    actual_metadata = await search_all(
+        executor,
         catalogs=[
             STACAPICollectionSearch(base_url=mock_api_url) for mock_api_url in mock_apis
-        ]
+        ],
     )
 
     assert (
@@ -19,12 +22,14 @@ def test_search_all(mock_apis):
     )  # all of the mocked collections in conftest.py
 
 
-def test_search_bbox(mock_apis):
-    actual_metadata = search_all(
+@pytest.mark.asyncio
+async def test_search_bbox(executor, mock_apis):
+    actual_metadata = await search_all(
+        executor,
         catalogs=[
             STACAPICollectionSearch(base_url=mock_api_url, bbox=(-100, 10, -90, 20))
             for mock_api_url in mock_apis
-        ]
+        ],
     )
 
     assert (
@@ -32,8 +37,10 @@ def test_search_bbox(mock_apis):
     )  # all but one of the mocked collections in conftest.py
 
 
-def test_search_datetime(mock_apis):
-    actual_metadata = search_all(
+@pytest.mark.asyncio
+async def test_search_datetime(executor, mock_apis):
+    actual_metadata = await search_all(
+        executor,
         catalogs=[
             STACAPICollectionSearch(
                 base_url=mock_api_url,
@@ -44,7 +51,7 @@ def test_search_datetime(mock_apis):
                 ),
             )
             for mock_api_url in mock_apis
-        ]
+        ],
     )
 
     assert (
@@ -52,9 +59,10 @@ def test_search_datetime(mock_apis):
     )  # all but one of the mocked collections in conftest.py
 
 
-def test_search_all_no_collections(mock_apis):
-    actual_metadata = search_all(
-        catalogs=[STACAPICollectionSearch(base_url=mock_apis[-1])]
+@pytest.mark.asyncio
+async def test_search_all_no_collections(executor, mock_apis):
+    actual_metadata = await search_all(
+        executor, catalogs=[STACAPICollectionSearch(base_url=mock_apis[-1])]
     )
 
     expected_metadata = []
@@ -62,11 +70,13 @@ def test_search_all_no_collections(mock_apis):
     assert list(actual_metadata) == expected_metadata
 
 
-def test_stac_api_and_cmr(mock_apis):
+@pytest.mark.asyncio
+async def test_stac_api_and_cmr(executor, mock_apis):
     # test a search that should only yield results from CMR
     text = "hls"
     actual_metadata = list(
-        search_all(
+        await search_all(
+            executor,
             catalogs=[
                 STACAPICollectionSearch(
                     base_url=mock_api_url,
@@ -79,7 +89,7 @@ def test_stac_api_and_cmr(mock_apis):
                     base_url=CMR_OPS,
                     text=text,
                 )
-            ]
+            ],
         )
     )
 
@@ -90,7 +100,8 @@ def test_stac_api_and_cmr(mock_apis):
     # test a search that should only yield results from the STAC APIs
     text = "awesome"
     actual_metadata = list(
-        search_all(
+        await search_all(
+            executor,
             catalogs=[
                 STACAPICollectionSearch(
                     base_url=mock_api_url,
@@ -103,7 +114,7 @@ def test_stac_api_and_cmr(mock_apis):
                     base_url=CMR_OPS,
                     text=text,
                 )
-            ]
+            ],
         )
     )
 


### PR DESCRIPTION
The goal of this PR is to improve the response time for the `/search` endpoint by running the child API requests concurrently. Now it should be as fast as the slowest child API request rather than the cumulative response time of all child API requests.

- **async search**: run `get_collection_metadata` method for all `CatalogSearch` instances in a `ThreadPoolExecutor`
- **add script for benchmarking response time**:
  - on `main`: average runtime of 2.3 seconds
  - on `hr/async`: average runtime of 1.7 seconds
- **update docker mount/copy configuration**: this should prevent inadvertent dependency conflicts when mounting the `app` directory.
