### PR TITLE
collect API errors and return messages in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker compose up --build
 This will use the `FEDERATED_STAC_API_URLS` and
 `FEDERATED_CMR_URLS` environment variables
 defined in [docker-compose.yaml](./docker-compose.yaml) to search across
-the Earth Search STAC (from E84), the eoapi.dev STAC, and NASA's CMR.
+NASA's MAAP STAC API and VEDA STAC API, and ESA's STAC API.
 
 Stop the services:
 

--- a/src/server/app/cmr_collection_search.py
+++ b/src/server/app/cmr_collection_search.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Iterable, List, TypedDict, Union
 
 from cmr import CollectionQuery
-from requests.exceptions import ConnectionError
+from requests.exceptions import RequestException
 
 from app.collection_search import CollectionSearch
 from app.hint import PYTHON, generate_cmr_hint
@@ -26,7 +26,7 @@ class CMRCollectionSearch(CollectionSearch):
         try:
             collection_search = CollectionQuery(mode=self.base_url)
             return "healthy" if collection_search.hits() else "no collections"
-        except ConnectionError:
+        except RequestException:
             return "cannot be opened by Python CMR client"
 
     def get_collection_metadata(
@@ -47,7 +47,7 @@ class CMRCollectionSearch(CollectionSearch):
                 self.collection_metadata(collection)
                 for collection in collection_search.get()
             )
-        except ConnectionError as e:
+        except RequestException as e:
             return [
                 FederatedSearchError(catalog_url=self.base_url, error_message=str(e))
             ]

--- a/src/server/app/cmr_collection_search.py
+++ b/src/server/app/cmr_collection_search.py
@@ -1,13 +1,13 @@
 import json
 from dataclasses import dataclass
-from typing import Iterable, List, TypedDict
+from typing import Iterable, List, TypedDict, Union
 
 from cmr import CollectionQuery
 from requests.exceptions import ConnectionError
 
 from app.collection_search import CollectionSearch
 from app.hint import PYTHON, generate_cmr_hint
-from app.models import CollectionMetadata
+from app.models import CollectionMetadata, FederatedSearchError
 
 
 class CMRCollectionResult(TypedDict, total=False):
@@ -29,21 +29,28 @@ class CMRCollectionSearch(CollectionSearch):
         except ConnectionError:
             return "cannot be opened by Python CMR client"
 
-    def get_collection_metadata(self) -> Iterable[CollectionMetadata]:
-        collection_search = CollectionQuery(mode=self.base_url)
-        if self.bbox:
-            collection_search = collection_search.bounding_box(*self.bbox)
+    def get_collection_metadata(
+        self,
+    ) -> Iterable[Union[CollectionMetadata, FederatedSearchError]]:
+        try:
+            collection_search = CollectionQuery(mode=self.base_url)
+            if self.bbox:
+                collection_search = collection_search.bounding_box(*self.bbox)
 
-        if self.datetime:
-            collection_search = collection_search.temporal(*self.datetime)
+            if self.datetime:
+                collection_search = collection_search.temporal(*self.datetime)
 
-        if self.text:
-            collection_search = collection_search.keyword(self.text)
+            if self.text:
+                collection_search = collection_search.keyword(self.text)
 
-        return (
-            self.collection_metadata(collection)
-            for collection in collection_search.get()
-        )
+            return (
+                self.collection_metadata(collection)
+                for collection in collection_search.get()
+            )
+        except ConnectionError as e:
+            return [
+                FederatedSearchError(catalog_url=self.base_url, error_message=str(e))
+            ]
 
     def collection_metadata(
         self, collection: CMRCollectionResult

--- a/src/server/app/collection_search.py
+++ b/src/server/app/collection_search.py
@@ -2,9 +2,9 @@ import itertools
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Iterable, Literal, Optional
+from typing import Iterable, Literal, Optional, Union
 
-from app.models import CollectionMetadata
+from app.models import CollectionMetadata, FederatedSearchError
 from app.shared import BBox, DatetimeInterval
 
 
@@ -17,7 +17,9 @@ class CollectionSearch(ABC):
     hint_lang: Optional[Literal["python"]] = None
 
     @abstractmethod
-    def get_collection_metadata(self) -> Iterable[CollectionMetadata]:
+    def get_collection_metadata(
+        self,
+    ) -> Iterable[Union[CollectionMetadata, FederatedSearchError]]:
         pass
 
     @abstractmethod
@@ -28,7 +30,7 @@ class CollectionSearch(ABC):
 async def search_all(
     executor: ThreadPoolExecutor,
     catalogs: Iterable[CollectionSearch],
-) -> Iterable[CollectionMetadata]:
+) -> Iterable[Union[CollectionMetadata, FederatedSearchError]]:
     return itertools.chain.from_iterable(
         executor.map(lambda catalog: catalog.get_collection_metadata(), catalogs)
     )

--- a/src/server/app/models.py
+++ b/src/server/app/models.py
@@ -15,5 +15,11 @@ class CollectionMetadata(BaseModel):
     hint: Optional[str] = None
 
 
+class FederatedSearchError(BaseModel):
+    catalog_url: str
+    error_message: str
+
+
 class SearchResponse(BaseModel):
     results: Iterable[CollectionMetadata]
+    errors: List[FederatedSearchError]

--- a/src/server/app/stac_api_collection_search.py
+++ b/src/server/app/stac_api_collection_search.py
@@ -91,15 +91,12 @@ class STACAPICollectionSearch(CollectionSearch):
             # this makes it possible to iterate through all collections
             catalog.add_conforms_to("COLLECTIONS")
 
-            return (
-                self.collection_metadata(collection)
-                for collection in catalog.get_collections()
-                if self.overlaps(collection)
-            )
+            for collection in catalog.get_collections():
+                if self.overlaps(collection):
+                    yield self.collection_metadata(collection)
+
         except APIError as e:
-            return [
-                FederatedSearchError(catalog_url=self.base_url, error_message=str(e))
-            ]
+            yield FederatedSearchError(catalog_url=self.base_url, error_message=str(e))
 
     def overlaps(self, collection: Collection) -> bool:
         return (

--- a/src/server/app/stac_api_collection_search.py
+++ b/src/server/app/stac_api_collection_search.py
@@ -91,9 +91,11 @@ class STACAPICollectionSearch(CollectionSearch):
             # this makes it possible to iterate through all collections
             catalog.add_conforms_to("COLLECTIONS")
 
-            for collection in catalog.get_collections():
-                if self.overlaps(collection):
-                    yield self.collection_metadata(collection)
+            yield from (
+                self.collection_metadata(collection)
+                for collection in catalog.get_collections()
+                if self.overlaps(collection)
+            )
 
         except APIError as e:
             yield FederatedSearchError(catalog_url=self.base_url, error_message=str(e))

--- a/src/server/tests/conftest.py
+++ b/src/server/tests/conftest.py
@@ -112,6 +112,9 @@ def mock_apis():
             }
             m.get(base_url, status_code=200, json=catalog_root_response)
 
+        # create an API endpoint that will result in an error
+        base_urls += ["http://fake-stac.net"]
+
         yield base_urls
 
 

--- a/src/server/tests/test_collection_search.py
+++ b/src/server/tests/test_collection_search.py
@@ -5,6 +5,7 @@ from cmr import CMR_OPS
 
 from app.cmr_collection_search import CMRCollectionSearch
 from app.collection_search import search_all
+from app.models import CollectionMetadata
 from app.stac_api_collection_search import STACAPICollectionSearch
 
 
@@ -18,7 +19,7 @@ async def test_search_all(executor, mock_apis):
     )
 
     assert (
-        len(list(actual_metadata)) == 4
+        len(list(actual_metadata)) == 5
     )  # all of the mocked collections in conftest.py
 
 
@@ -33,7 +34,7 @@ async def test_search_bbox(executor, mock_apis):
     )
 
     assert (
-        len(list(actual_metadata)) == 3
+        len(list(actual_metadata)) == 4
     )  # all but one of the mocked collections in conftest.py
 
 
@@ -55,14 +56,14 @@ async def test_search_datetime(executor, mock_apis):
     )
 
     assert (
-        len(list(actual_metadata)) == 2
+        len(list(actual_metadata)) == 3
     )  # all but one of the mocked collections in conftest.py
 
 
 @pytest.mark.asyncio
 async def test_search_all_no_collections(executor, mock_apis):
     actual_metadata = await search_all(
-        executor, catalogs=[STACAPICollectionSearch(base_url=mock_apis[-1])]
+        executor, catalogs=[STACAPICollectionSearch(base_url=mock_apis[-2])]
     )
 
     expected_metadata = []
@@ -95,7 +96,8 @@ async def test_stac_api_and_cmr(executor, mock_apis):
 
     assert len(actual_metadata) > 1
     for result in actual_metadata:
-        assert result.catalog_url == CMR_OPS
+        if isinstance(result, CollectionMetadata):
+            assert result.catalog_url == CMR_OPS
 
     # test a search that should only yield results from the STAC APIs
     text = "awesome"

--- a/src/server/tests/test_stac_api_collection_search.py
+++ b/src/server/tests/test_stac_api_collection_search.py
@@ -83,6 +83,7 @@ def test_api_error():
         base_url="http://nope",
     )
 
-    results = list(base_search.get_collection_metadata())
-    for result in results:
-        assert isinstance(result, FederatedSearchError)
+    assert all(
+        isinstance(result, FederatedSearchError)
+        for result in base_search.get_collection_metadata()
+    )

--- a/src/server/tests/test_stac_api_collection_search.py
+++ b/src/server/tests/test_stac_api_collection_search.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from app.hint import PYTHON
+from app.models import CollectionMetadata, FederatedSearchError
 from app.stac_api_collection_search import STACAPICollectionSearch
 
 
@@ -70,6 +71,18 @@ def test_hint(mock_apis):
         "\nitem_collection = search.item_collection()"
     )
     for i, result in enumerate(results):
+        assert isinstance(result, CollectionMetadata)
         assert result.hint
         if i == 0:
             assert result.hint.strip() == expected_hint.strip()
+
+
+def test_api_error():
+    # a search against an API that doesn't exist
+    base_search = STACAPICollectionSearch(
+        base_url="http://nope",
+    )
+
+    results = list(base_search.get_collection_metadata())
+    for result in results:
+        assert isinstance(result, FederatedSearchError)


### PR DESCRIPTION
**Goal**: catch API errors so if any of the APIs break the federated search application can still return results from the other APIs.

I tried a few ideas out for catching API errors and landed on this one in order to maintain low latency and keep as much of the async / generator machinery in place.

Other options I considered:

- Add an `error` attribute to the `CollectionMetadata` model that could be used to filter errors out when returning the response in the `/search` endpoint

- Have `CollectionSearch.get_collection_metadata()` return a tuple of successful results and errors

I think the approach that I took allows everything to happen as lazily as possible and provides a clean way to separate successful searches from errors at the end.

Resolves #8  