### PR TITLE
Implement free-text search as defined in OGC API Features spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -377,3 +377,5 @@ Temporary Items
 .nfs*
 
 # End of https://www.toptal.com/developers/gitignore/api/linux
+
+.envrc

--- a/src/server/app/cmr_collection_search.py
+++ b/src/server/app/cmr_collection_search.py
@@ -1,4 +1,5 @@
 import json
+from copy import copy
 from dataclasses import dataclass
 from typing import Iterable, List, TypedDict, Union
 
@@ -6,6 +7,7 @@ from cmr import CollectionQuery
 from requests.exceptions import RequestException
 
 from app.collection_search import CollectionSearch
+from app.free_text import parse_query_for_cmr
 from app.hint import PYTHON, generate_cmr_hint
 from app.models import CollectionMetadata, FederatedSearchError
 
@@ -33,6 +35,8 @@ class CMRCollectionSearch(CollectionSearch):
         self,
     ) -> Iterable[Union[CollectionMetadata, FederatedSearchError]]:
         try:
+            collection_searches = []
+
             collection_search = CollectionQuery(mode=self.base_url)
             if self.bbox:
                 collection_search = collection_search.bounding_box(*self.bbox)
@@ -41,16 +45,24 @@ class CMRCollectionSearch(CollectionSearch):
                 collection_search = collection_search.temporal(*self.datetime)
 
             if self.q:
-                collection_search = collection_search.keyword(self.q)
+                # parse the q parameter so we can send OR queries as separate requests
+                q_parsed = parse_query_for_cmr(self.q)
+                # if it requires multiple separate queries identify them and add them
+                # to the list
+                for _q in q_parsed:
+                    _collection_search = copy(collection_search)
 
-            return (
+                    collection_searches.append(_collection_search.keyword(_q))
+            else:
+                collection_searches.append(collection_search)
+
+            yield from (
                 self.collection_metadata(collection)
-                for collection in collection_search.get()
+                for collection_search in collection_searches
+                for collection in set(collection_search.get())
             )
-        except RequestException as e:
-            return [
-                FederatedSearchError(catalog_url=self.base_url, error_message=str(e))
-            ]
+        except Exception as e:
+            yield FederatedSearchError(catalog_url=self.base_url, error_message=str(e))
 
     def collection_metadata(
         self, collection: CMRCollectionResult

--- a/src/server/app/cmr_collection_search.py
+++ b/src/server/app/cmr_collection_search.py
@@ -40,8 +40,8 @@ class CMRCollectionSearch(CollectionSearch):
             if self.datetime:
                 collection_search = collection_search.temporal(*self.datetime)
 
-            if self.text:
-                collection_search = collection_search.keyword(self.text)
+            if self.q:
+                collection_search = collection_search.keyword(self.q)
 
             return (
                 self.collection_metadata(collection)

--- a/src/server/app/collection_search.py
+++ b/src/server/app/collection_search.py
@@ -13,7 +13,7 @@ class CollectionSearch(ABC):
     base_url: str
     bbox: Optional[BBox] = None
     datetime: Optional[DatetimeInterval] = None
-    text: Optional[str] = None
+    q: Optional[str] = None
     hint_lang: Optional[Literal["python"]] = None
 
     @abstractmethod

--- a/src/server/app/free_text.py
+++ b/src/server/app/free_text.py
@@ -138,7 +138,7 @@ def parse_query_for_cmr(q) -> List[str]:
             separate_or_queries.append(token)
         elif "(" in token and ")" in token:
             raise ValueError(
-                "CMR free-text search does not handle exclusion parenthetetical terms "
+                "CMR free-text search does not handle parenthetetical terms "
                 f"like {token}\n"
                 f"full query: {q}"
             )

--- a/src/server/app/free_text.py
+++ b/src/server/app/free_text.py
@@ -1,0 +1,165 @@
+"""Free-text search as described in OGC API - Features - Part 9: Text Search
+https://docs.ogc.org/DRAFTS/24-031.html#q-parameter
+
+That is the SPEC that the collection-search STAC API extension is meant to follow,
+but there are some inconsistencies in the described examples regarding spaces
+and whether they should represent OR or AND clauses!
+
+https://github.com/stac-api-extensions/freetext-search/blob/master/README.md#http-get
+
+This implementation respects the OGC API spec and treats spaces as AND clauses.
+"""
+
+import re
+from typing import List
+
+
+def escape_regex(term):
+    return re.escape(term)
+
+
+def handle_exact_phrase(phrase):
+    # Match exact phrase including spaces
+    return r"\b{}\b".format(re.escape(phrase.strip('"')))
+
+
+def handle_or_terms(terms):
+    # Match any one of the terms
+    return "|".join(map(escape_regex, terms))
+
+
+def handle_inclusion_exclusion(token):
+    if token.startswith("+"):
+        term = token[1:]
+        return r"(?=.*\b{}\b)".format(escape_regex(term))
+    elif token.startswith("-"):
+        term = token[1:]
+        return r"(?!.*\b{}\b)".format(escape_regex(term))
+    else:
+        return escape_regex(token)
+
+
+def merge_parts_with_and(tokens):
+    # Merging parts ensuring all must match
+    return "(?=.*{})".format(")(?=.*".join(tokens))
+
+
+def parse_query_for_ogc(q):
+    regex_parts = []
+
+    # break the query into individual terms, quoted statements, and parentheses
+    tokens = [
+        token.strip() for token in re.findall(r"\".*?\"|\([^\)]*\)|,|[^,\s]+|\s", q)
+    ]
+
+    # track terms that need to be combined in an AND statement
+    current_and_terms = []
+
+    for token in tokens:
+        if not token:
+            continue
+        if token == ",":
+            token = "OR"
+        if token == "AND":
+            continue
+        elif token == "OR":
+            # collect terms that need to be collapsed in an AND statement, continue
+            if current_and_terms:
+                regex_parts.append(merge_parts_with_and(current_and_terms))
+                current_and_terms = []
+        elif token.startswith('"') and token.endswith('"'):
+            # handle the exact phrase term
+            current_and_terms.append(handle_exact_phrase(token))
+        elif "(" in token and ")" in token:
+            # recursively parse parenthetical statements
+            inner_query = token.strip("()")
+            current_and_terms.append("({})".format(parse_query_for_ogc(inner_query)))
+        elif token.startswith("+") or token.startswith("-"):
+            current_and_terms.append(handle_inclusion_exclusion(token))
+        else:
+            if "AND" in token:
+                and_terms = list(map(str.strip, token.split("AND")))
+                current_and_terms.append(merge_parts_with_and(and_terms))
+            elif "OR" in token:
+                or_terms = list(map(str.strip, token.split("OR")))
+                regex_parts.append(handle_or_terms(or_terms))
+            else:
+                current_and_terms.append(escape_regex(token))
+
+    if current_and_terms:
+        regex_parts.append(merge_parts_with_and(current_and_terms))
+
+    # Join OR sets (or a single OR-less set)
+    regex = "|".join(regex_parts)
+
+    return regex
+
+
+def apply_regex(regex, text) -> bool:
+    """Apply the regex to the given text and return if there's a match."""
+    pattern = re.compile(regex, re.IGNORECASE)
+    return bool(pattern.search(text))
+
+
+def parse_query_for_cmr(q) -> List[str]:
+    """CMR free-text search cannot handle a mixture of exact terms and phrases,
+    cannot handle OR queries. Complex queries must be sent separately and the
+    results must be combined appropriately
+    """
+    separate_or_queries = []
+
+    # break the query into individual terms, quoted statements, and parentheses
+    tokens = [
+        token.strip() for token in re.findall(r"\".*?\"|\([^\)]*\)|,|[^,\s]+|\s", q)
+    ]
+
+    # track terms that need to be combined in an AND statement
+    current_and_terms: List[str] = []
+
+    for token in tokens:
+        if not token:
+            continue
+        if token == ",":
+            # commas are interpreted as OR statements
+            token = "OR"
+
+        if token == "AND":
+            continue
+        elif token == "OR":
+            # collect terms that need to be collapsed in an AND statement, continue
+            if current_and_terms:
+                separate_or_queries.append(" ".join(current_and_terms))
+                current_and_terms = []
+        elif token.startswith('"') and token.endswith('"'):
+            # handle the exact phrase term
+            if current_and_terms:
+                separate_or_queries.append(" ".join(current_and_terms))
+                current_and_terms = []
+            separate_or_queries.append(token)
+        elif "(" in token and ")" in token:
+            raise ValueError(
+                "CMR free-text search does not handle exclusion parenthetetical terms "
+                f"like {token}\n"
+                f"full query: {q}"
+            )
+        elif token.startswith("+"):
+            current_and_terms.append(handle_inclusion_exclusion(token))
+        elif token.startswith("-"):
+            raise ValueError(
+                f"CMR free-text search does not handle exclusion terms like {token}\n"
+                f"full query: {q}"
+            )
+        else:
+            if "AND" in token:
+                and_terms = list(map(str.strip, token.split("AND")))
+                current_and_terms.append(" ".join(and_terms))
+            elif "OR" in token:
+                or_terms = list(map(str.strip, token.split("OR")))
+                separate_or_queries.extend(or_terms)
+            else:
+                current_and_terms.append(token)
+
+    if current_and_terms:
+        separate_or_queries.append(" ".join(current_and_terms))
+
+    return separate_or_queries

--- a/src/server/app/main.py
+++ b/src/server/app/main.py
@@ -147,7 +147,7 @@ async def search_collections(
             base_url=base_url,
             bbox=parsed_bbox,
             datetime=datetime_interval,
-            text=text,
+            q=text,
             hint_lang=hint_lang,
         )
         for base_url in settings.stac_api_urls
@@ -156,7 +156,7 @@ async def search_collections(
             base_url=base_url,
             bbox=parsed_bbox,
             datetime=datetime_interval,
-            text=text,
+            q=text,
             hint_lang=hint_lang,
         )
         for base_url in settings.cmr_urls

--- a/src/server/app/stac_api_collection_search.py
+++ b/src/server/app/stac_api_collection_search.py
@@ -132,7 +132,7 @@ class STACAPICollectionSearch(CollectionSearch):
             if text
         }
 
-        return not self.text or contains_ignorecase(self.text, text_fields)
+        return not self.q or contains_ignorecase(self.q, text_fields)
 
     def collection_metadata(self, collection: Collection) -> CollectionMetadata:
         hint = (

--- a/src/server/app/stac_api_collection_search.py
+++ b/src/server/app/stac_api_collection_search.py
@@ -6,6 +6,7 @@ from pystac_client.client import Client
 from pystac_client.exceptions import APIError
 
 from app.collection_search import CollectionSearch
+from app.free_text import apply_regex, parse_query_for_ogc
 from app.hint import PYTHON, generate_pystac_client_hint
 from app.models import CollectionMetadata, FederatedSearchError
 from app.shared import BBox, DatetimeInterval
@@ -57,11 +58,12 @@ def datetime_intervals_overlap(
     return (start2 or dtmin) <= (end1 or dtmax) and (start1 or dtmin) <= (end2 or dtmax)
 
 
-def contains_ignorecase(
-    text: str,
+def matches_regex(
+    q: str,
     text_fields: set[str],
 ) -> bool:
-    return any(text.lower() in x.lower() for x in text_fields)
+    regex = parse_query_for_ogc(q)
+    return any(apply_regex(regex, text_field) for text_field in text_fields)
 
 
 class STACAPICollectionSearch(CollectionSearch):
@@ -132,7 +134,7 @@ class STACAPICollectionSearch(CollectionSearch):
             if text
         }
 
-        return not self.q or contains_ignorecase(self.q, text_fields)
+        return not self.q or matches_regex(self.q, text_fields)
 
     def collection_metadata(self, collection: Collection) -> CollectionMetadata:
         hint = (

--- a/src/server/tests/test_collection_search.py
+++ b/src/server/tests/test_collection_search.py
@@ -81,14 +81,14 @@ async def test_stac_api_and_cmr(executor, mock_apis):
             catalogs=[
                 STACAPICollectionSearch(
                     base_url=mock_api_url,
-                    text=text,
+                    q=text,
                 )
                 for mock_api_url in mock_apis
             ]
             + [
                 CMRCollectionSearch(
                     base_url=CMR_OPS,
-                    text=text,
+                    q=text,
                 )
             ],
         )
@@ -107,14 +107,14 @@ async def test_stac_api_and_cmr(executor, mock_apis):
             catalogs=[
                 STACAPICollectionSearch(
                     base_url=mock_api_url,
-                    text=text,
+                    q=text,
                 )
                 for mock_api_url in mock_apis
             ]
             + [
                 CMRCollectionSearch(
                     base_url=CMR_OPS,
-                    text=text,
+                    q=text,
                 )
             ],
         )

--- a/src/server/tests/test_free_text.py
+++ b/src/server/tests/test_free_text.py
@@ -1,0 +1,133 @@
+import pytest
+
+from app.free_text import apply_regex, parse_query_for_cmr, parse_query_for_ogc
+
+
+def test_ogc_single_term():
+    query = "sentinel"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "The sentinel node was true")
+    assert not apply_regex(regex, "No match here")
+
+
+def test_ogc_exact_phrase():
+    query = '"climate model"'
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "The climate model is impressive")
+    assert not apply_regex(regex, "This model is for climate modeling")
+
+    # an exact phrase with a comma inside
+    query = '"models, etc"'
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "Produced with equations, and models, etc.")
+    assert not apply_regex(regex, "Produced with models")
+
+
+def test_ogc_and_terms_default():
+    query = "climate model"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "Climate change is a significant modeling challenge")
+    assert apply_regex(regex, "The model was developed using climate observation data")
+    assert not apply_regex(regex, "This is an advanced model")
+    assert not apply_regex(regex, "No relevant terms here")
+
+
+def test_ogc_or_terms_explicit():
+    query = "climate OR model"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "Climate discussion")
+    assert apply_regex(regex, "FPGA model creation")
+    assert not apply_regex(regex, "No matching term here")
+
+
+def test_ogc_or_terms_commas():
+    query = "climate,model"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "Climate change is here")
+    assert apply_regex(regex, "They built a model train")
+    assert apply_regex(regex, "It's a climate model!")
+    assert not apply_regex(regex, "It's a mathematical equation")
+
+
+def test_ogc_and_terms():
+    query = "climate AND model"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "The climate model is impressive")
+    assert not apply_regex(regex, "This climate change discussion")
+    assert not apply_regex(regex, "Advanced model system")
+
+
+def test_ogc_parentheses_grouping():
+    query = "(quick OR brown) AND fox"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "The quick brown fox")
+    assert apply_regex(regex, "A quick fox jumps")
+    assert apply_regex(regex, "brown bear and a fox")
+    assert not apply_regex(regex, "The fox is clever")
+
+    query = "(quick AND brown) OR (fast AND red)"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "quick brown fox")
+    assert apply_regex(regex, "fast red car")
+    assert not apply_regex(regex, "quick red car")
+
+
+def test_ogc_inclusions_exclusions():
+    query = "quick +brown -fox"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "The quick brown bear")
+    assert not apply_regex(regex, "The quick fox")
+    assert not apply_regex(regex, "The quickest")
+    assert apply_regex(regex, "A quick light brown jumper")
+
+
+def test_ogc_partial_match():
+    query = "climat"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "climatology")
+    assert apply_regex(regex, "climate")
+    assert not apply_regex(regex, "climbing")
+
+
+def test_cmr_single_term():
+    query = "climate"
+    cmr_queries = parse_query_for_cmr(query)
+    assert cmr_queries == [query]
+
+
+def test_cmr_comma_or():
+    query = "climate,model,uncertainty"
+    cmr_queries = parse_query_for_cmr(query)
+    assert set(cmr_queries) == set(["climate", "model", "uncertainty"])
+
+
+def test_cmr_parentheses():
+    query = "(quick AND brown) OR (fast AND red)"
+    with pytest.raises(ValueError):
+        parse_query_for_cmr(query)
+    # assert set(cmr_queries) == set(["quick brown", "fast red"])
+
+
+def test_cmr_exact():
+    query = '"climate change","global warming"'
+    cmr_queries = parse_query_for_cmr(query)
+    assert set(cmr_queries) == set(['"climate change"', '"global warming"'])
+
+
+def test_cmr_default_and():
+    query = "climate change model temperature"
+    cmr_queries = parse_query_for_cmr(query)
+    assert cmr_queries == [query]
+
+
+def test_cmr_keyword_and_phrase():
+    query = '"climate model" temperature'
+    cmr_queries = parse_query_for_cmr(query)
+    assert set(cmr_queries) == set(['"climate model"', "temperature"])
+
+
+def test_cmr_and_parentheses():
+    query = "climate AND (warming OR cooling)"
+    with pytest.raises(ValueError):
+        parse_query_for_cmr(query)
+    # assert set(cmr_queries) == set(["climate warming", "climate cooling"])

--- a/src/server/tests/test_stac_api_collection_search.py
+++ b/src/server/tests/test_stac_api_collection_search.py
@@ -50,7 +50,7 @@ def test_text(mock_apis):
     # filter by free-text search
     text_search = STACAPICollectionSearch(
         base_url=mock_apis[0],
-        text="another",
+        q="another",
     )
     assert len(list(text_search.get_collection_metadata())) == 1
 


### PR DESCRIPTION
These changes increase the flexibility of the free-text search capability in the API. Rather than simply checking to see if the text fields of a collection contain the entire query string, this follows the simple query language defined in the [OGC API - Features spec](https://docs.ogc.org/DRAFTS/24-031.html#q-parameter) which is what the [free-text search STAC API extension](https://github.com/stac-api-extensions/freetext-search/blob/master/README.md#http-get) follows.

The `q` parameter is parsed into a regex statement that is used to find matches in collection text fields. I am not a regex wizard so the result is not pretty, but right now it achieves the goal of translating plain-text queries into regex that can be used to check text fields for matches. The parser is working on all of the test cases that I defined in `test_free_text.py`.

Sadly, the CMR collection search uses an entirely separate query language (see [CMR API docs](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#c-keyword) for details). Right now, a CMR query that uses the `q` parameter from this application for the `keywords` will work for simple cases e.g. "climate,temperature,precipitation", but will fail (loudly) for more complex queries like "climate AND (temperature OR precipitation)". OR queries are not allowed in the CMR search, so I adapted the `get_collection_metadata` method to send separate queries for each OR statement then combine the results.
