### PR TITLE
Use sqlite free-text search function instead of regex

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,6 @@ on:
     tags:
       - '*'
   pull_request:
-    branches:
-      - main
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -377,3 +377,5 @@ Temporary Items
 .nfs*
 
 # End of https://www.toptal.com/developers/gitignore/api/linux
+
+.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - Make the client application responsive to window size
+- Implement free-text search as defined by
+[Free-Text STAC API extension](https://github.com/stac-api-extensions/freetext-search)
+([#14](https://github.com/developmentseed/federated-collection-discovery/pull/1))
 
 ## 0.1.0
 

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -26,7 +26,7 @@ export const App = () => {
   const handleSearch = async (formData: {
     bbox: string;
     datetime: string;
-    text: string;
+    q: string;
   }) => {
     setLoading(true);
     try {

--- a/src/client/src/api/search.ts
+++ b/src/client/src/api/search.ts
@@ -1,7 +1,7 @@
 type SearchParams = {
   bbox: string;
   datetime: string;
-  text: string;
+  q: string;
 };
 
 export const API_URL = process.env.REACT_APP_API_URL || "http://localhost:8000";

--- a/src/client/src/components/SearchForm.tsx
+++ b/src/client/src/components/SearchForm.tsx
@@ -22,7 +22,7 @@ import "../css/react-datepicker.css";
 type FormData = {
   bbox: string;
   datetime: string;
-  text: string;
+  q: string;
   hint_lang: string;
 };
 
@@ -50,7 +50,7 @@ const SearchForm: React.FC<Props> = ({ onSubmit }) => {
     bbox: "",
     startDatetime: null,
     endDatetime: null,
-    text: "",
+    q: "",
     hint_lang: "python",
   });
 
@@ -95,7 +95,7 @@ const SearchForm: React.FC<Props> = ({ onSubmit }) => {
     const submitData = {
       bbox: formData.bbox,
       datetime,
-      text: formData.text,
+      q: formData.q,
       hint_lang: formData.hint_lang,
     };
     onSubmit(submitData);
@@ -156,11 +156,11 @@ const SearchForm: React.FC<Props> = ({ onSubmit }) => {
             </FormControl>
           </Flex>
         </FormControl>
-        <FormControl id="text">
+        <FormControl id="q">
           <FormLabel>Text Search</FormLabel>
           <Input
-            name="text"
-            value={formData.text}
+            name="q"
+            value={formData.q}
             onChange={handleChange}
             placeholder="Enter text"
           />

--- a/src/server/federated_collection_discovery/cmr_collection_search.py
+++ b/src/server/federated_collection_discovery/cmr_collection_search.py
@@ -43,8 +43,8 @@ class CMRCollectionSearch(CollectionSearch):
             if self.datetime:
                 collection_search = collection_search.temporal(*self.datetime)
 
-            if self.text:
-                collection_search = collection_search.keyword(self.text)
+            if self.q:
+                collection_search = collection_search.keyword(self.q)
 
             return (
                 self.collection_metadata(collection)

--- a/src/server/federated_collection_discovery/cmr_collection_search.py
+++ b/src/server/federated_collection_discovery/cmr_collection_search.py
@@ -1,4 +1,5 @@
 import json
+from copy import copy
 from dataclasses import dataclass
 from typing import Iterable, List, TypedDict, Union
 
@@ -6,6 +7,7 @@ from cmr import CollectionQuery
 from requests.exceptions import RequestException
 
 from federated_collection_discovery.collection_search import CollectionSearch
+from federated_collection_discovery.free_text import parse_query_for_cmr
 from federated_collection_discovery.hint import PYTHON, generate_cmr_hint
 from federated_collection_discovery.models import (
     CollectionMetadata,
@@ -36,6 +38,8 @@ class CMRCollectionSearch(CollectionSearch):
         self,
     ) -> Iterable[Union[CollectionMetadata, FederatedSearchError]]:
         try:
+            collection_searches = []
+
             collection_search = CollectionQuery(mode=self.base_url)
             if self.bbox:
                 collection_search = collection_search.bounding_box(*self.bbox)
@@ -44,16 +48,24 @@ class CMRCollectionSearch(CollectionSearch):
                 collection_search = collection_search.temporal(*self.datetime)
 
             if self.q:
-                collection_search = collection_search.keyword(self.q)
+                # parse the q parameter so we can send OR queries as separate requests
+                q_parsed = parse_query_for_cmr(self.q)
+                # if it requires multiple separate queries identify them and add them
+                # to the list
+                for _q in q_parsed:
+                    _collection_search = copy(collection_search)
 
-            return (
+                    collection_searches.append(_collection_search.keyword(_q))
+            else:
+                collection_searches.append(collection_search)
+
+            yield from (
                 self.collection_metadata(collection)
-                for collection in collection_search.get()
+                for collection_search in collection_searches
+                for collection in set(collection_search.get())
             )
-        except RequestException as e:
-            return [
-                FederatedSearchError(catalog_url=self.base_url, error_message=str(e))
-            ]
+        except Exception as e:
+            yield FederatedSearchError(catalog_url=self.base_url, error_message=str(e))
 
     def collection_metadata(
         self, collection: CMRCollectionResult

--- a/src/server/federated_collection_discovery/collection_search.py
+++ b/src/server/federated_collection_discovery/collection_search.py
@@ -16,7 +16,7 @@ class CollectionSearch(ABC):
     base_url: str
     bbox: Optional[BBox] = None
     datetime: Optional[DatetimeInterval] = None
-    text: Optional[str] = None
+    q: Optional[str] = None
     hint_lang: Optional[Literal["python"]] = None
 
     @abstractmethod

--- a/src/server/federated_collection_discovery/free_text.py
+++ b/src/server/federated_collection_discovery/free_text.py
@@ -138,7 +138,7 @@ def parse_query_for_cmr(q) -> List[str]:
             separate_or_queries.append(token)
         elif "(" in token and ")" in token:
             raise ValueError(
-                "CMR free-text search does not handle exclusion parenthetetical terms "
+                "CMR free-text search does not handle parenthetetical terms "
                 f"like {token}\n"
                 f"full query: {q}"
             )

--- a/src/server/federated_collection_discovery/free_text.py
+++ b/src/server/federated_collection_discovery/free_text.py
@@ -1,0 +1,165 @@
+"""Free-text search as described in OGC API - Features - Part 9: Text Search
+https://docs.ogc.org/DRAFTS/24-031.html#q-parameter
+
+That is the SPEC that the collection-search STAC API extension is meant to follow,
+but there are some inconsistencies in the described examples regarding spaces
+and whether they should represent OR or AND clauses!
+
+https://github.com/stac-api-extensions/freetext-search/blob/master/README.md#http-get
+
+This implementation respects the OGC API spec and treats spaces as AND clauses.
+"""
+
+import re
+from typing import List
+
+
+def escape_regex(term):
+    return re.escape(term)
+
+
+def handle_exact_phrase(phrase):
+    # Match exact phrase including spaces
+    return r"\b{}\b".format(re.escape(phrase.strip('"')))
+
+
+def handle_or_terms(terms):
+    # Match any one of the terms
+    return "|".join(map(escape_regex, terms))
+
+
+def handle_inclusion_exclusion(token):
+    if token.startswith("+"):
+        term = token[1:]
+        return r"(?=.*\b{}\b)".format(escape_regex(term))
+    elif token.startswith("-"):
+        term = token[1:]
+        return r"(?!.*\b{}\b)".format(escape_regex(term))
+    else:
+        return escape_regex(token)
+
+
+def merge_parts_with_and(tokens):
+    # Merging parts ensuring all must match
+    return "(?=.*{})".format(")(?=.*".join(tokens))
+
+
+def parse_query_for_ogc(q):
+    regex_parts = []
+
+    # break the query into individual terms, quoted statements, and parentheses
+    tokens = [
+        token.strip() for token in re.findall(r"\".*?\"|\([^\)]*\)|,|[^,\s]+|\s", q)
+    ]
+
+    # track terms that need to be combined in an AND statement
+    current_and_terms = []
+
+    for token in tokens:
+        if not token:
+            continue
+        if token == ",":
+            token = "OR"
+        if token == "AND":
+            continue
+        elif token == "OR":
+            # collect terms that need to be collapsed in an AND statement, continue
+            if current_and_terms:
+                regex_parts.append(merge_parts_with_and(current_and_terms))
+                current_and_terms = []
+        elif token.startswith('"') and token.endswith('"'):
+            # handle the exact phrase term
+            current_and_terms.append(handle_exact_phrase(token))
+        elif "(" in token and ")" in token:
+            # recursively parse parenthetical statements
+            inner_query = token.strip("()")
+            current_and_terms.append("({})".format(parse_query_for_ogc(inner_query)))
+        elif token.startswith("+") or token.startswith("-"):
+            current_and_terms.append(handle_inclusion_exclusion(token))
+        else:
+            if "AND" in token:
+                and_terms = list(map(str.strip, token.split("AND")))
+                current_and_terms.append(merge_parts_with_and(and_terms))
+            elif "OR" in token:
+                or_terms = list(map(str.strip, token.split("OR")))
+                regex_parts.append(handle_or_terms(or_terms))
+            else:
+                current_and_terms.append(escape_regex(token))
+
+    if current_and_terms:
+        regex_parts.append(merge_parts_with_and(current_and_terms))
+
+    # Join OR sets (or a single OR-less set)
+    regex = "|".join(regex_parts)
+
+    return regex
+
+
+def apply_regex(regex, text) -> bool:
+    """Apply the regex to the given text and return if there's a match."""
+    pattern = re.compile(regex, re.IGNORECASE)
+    return bool(pattern.search(text))
+
+
+def parse_query_for_cmr(q) -> List[str]:
+    """CMR free-text search cannot handle a mixture of exact terms and phrases,
+    cannot handle OR queries. Complex queries must be sent separately and the
+    results must be combined appropriately
+    """
+    separate_or_queries = []
+
+    # break the query into individual terms, quoted statements, and parentheses
+    tokens = [
+        token.strip() for token in re.findall(r"\".*?\"|\([^\)]*\)|,|[^,\s]+|\s", q)
+    ]
+
+    # track terms that need to be combined in an AND statement
+    current_and_terms: List[str] = []
+
+    for token in tokens:
+        if not token:
+            continue
+        if token == ",":
+            # commas are interpreted as OR statements
+            token = "OR"
+
+        if token == "AND":
+            continue
+        elif token == "OR":
+            # collect terms that need to be collapsed in an AND statement, continue
+            if current_and_terms:
+                separate_or_queries.append(" ".join(current_and_terms))
+                current_and_terms = []
+        elif token.startswith('"') and token.endswith('"'):
+            # handle the exact phrase term
+            if current_and_terms:
+                separate_or_queries.append(" ".join(current_and_terms))
+                current_and_terms = []
+            separate_or_queries.append(token)
+        elif "(" in token and ")" in token:
+            raise ValueError(
+                "CMR free-text search does not handle exclusion parenthetetical terms "
+                f"like {token}\n"
+                f"full query: {q}"
+            )
+        elif token.startswith("+"):
+            current_and_terms.append(handle_inclusion_exclusion(token))
+        elif token.startswith("-"):
+            raise ValueError(
+                f"CMR free-text search does not handle exclusion terms like {token}\n"
+                f"full query: {q}"
+            )
+        else:
+            if "AND" in token:
+                and_terms = list(map(str.strip, token.split("AND")))
+                current_and_terms.append(" ".join(and_terms))
+            elif "OR" in token:
+                or_terms = list(map(str.strip, token.split("OR")))
+                separate_or_queries.extend(or_terms)
+            else:
+                current_and_terms.append(token)
+
+    if current_and_terms:
+        separate_or_queries.append(" ".join(current_and_terms))
+
+    return separate_or_queries

--- a/src/server/federated_collection_discovery/main.py
+++ b/src/server/federated_collection_discovery/main.py
@@ -131,7 +131,7 @@ async def search_collections(
             "or 2024-06-01T00:00:00/2024-06-30T23:59:59Z",
         ),
     ] = None,
-    text: Annotated[
+    q: Annotated[
         Optional[str],
         Query(
             description=(
@@ -156,7 +156,7 @@ async def search_collections(
             base_url=base_url,
             bbox=parsed_bbox,
             datetime=datetime_interval,
-            q=text,
+            q=q,
             hint_lang=hint_lang,
         )
         for base_url in settings.stac_api_urls
@@ -165,7 +165,7 @@ async def search_collections(
             base_url=base_url,
             bbox=parsed_bbox,
             datetime=datetime_interval,
-            q=text,
+            q=q,
             hint_lang=hint_lang,
         )
         for base_url in settings.cmr_urls

--- a/src/server/federated_collection_discovery/main.py
+++ b/src/server/federated_collection_discovery/main.py
@@ -156,7 +156,7 @@ async def search_collections(
             base_url=base_url,
             bbox=parsed_bbox,
             datetime=datetime_interval,
-            text=text,
+            q=text,
             hint_lang=hint_lang,
         )
         for base_url in settings.stac_api_urls
@@ -165,7 +165,7 @@ async def search_collections(
             base_url=base_url,
             bbox=parsed_bbox,
             datetime=datetime_interval,
-            text=text,
+            q=text,
             hint_lang=hint_lang,
         )
         for base_url in settings.cmr_urls

--- a/src/server/federated_collection_discovery/stac_api_collection_search.py
+++ b/src/server/federated_collection_discovery/stac_api_collection_search.py
@@ -6,7 +6,7 @@ from pystac_client.client import Client
 from pystac_client.exceptions import APIError
 
 from federated_collection_discovery.collection_search import CollectionSearch
-from federated_collection_discovery.free_text import apply_regex, parse_query_for_ogc
+from federated_collection_discovery.free_text import sqlite_text_search
 from federated_collection_discovery.hint import PYTHON, generate_pystac_client_hint
 from federated_collection_discovery.models import (
     CollectionMetadata,
@@ -59,14 +59,6 @@ def datetime_intervals_overlap(
     dtmax = datetime.max.replace(tzinfo=timezone.utc)
 
     return (start2 or dtmin) <= (end1 or dtmax) and (start1 or dtmin) <= (end2 or dtmax)
-
-
-def matches_regex(
-    q: str,
-    text_fields: set[str],
-) -> bool:
-    regex = parse_query_for_ogc(q)
-    return any(apply_regex(regex, text_field) for text_field in text_fields)
 
 
 class STACAPICollectionSearch(CollectionSearch):
@@ -126,18 +118,16 @@ class STACAPICollectionSearch(CollectionSearch):
         )
 
     def textually_overlaps(self, collection: Collection) -> bool:
-        text_fields: set[str] = {
-            text
-            for text in [
-                collection.id,
-                collection.title,
-                collection.description,
-                *(collection.keywords or []),
-            ]
-            if text
+        text_fields: dict[str, str] = {
+            key: text
+            for key, text in collection.to_dict().items()
+            if text and key in ["title", "description", "keywords"]
         }
 
-        return not self.q or matches_regex(self.q, text_fields)
+        if text_fields.get("keywords"):
+            text_fields["keywords"] = ", ".join(text_fields["keywords"])
+
+        return not self.q or sqlite_text_search(self.q, text_fields)
 
     def collection_metadata(self, collection: Collection) -> CollectionMetadata:
         hint = (

--- a/src/server/federated_collection_discovery/stac_api_collection_search.py
+++ b/src/server/federated_collection_discovery/stac_api_collection_search.py
@@ -135,7 +135,7 @@ class STACAPICollectionSearch(CollectionSearch):
             if text
         }
 
-        return not self.text or contains_ignorecase(self.text, text_fields)
+        return not self.q or contains_ignorecase(self.q, text_fields)
 
     def collection_metadata(self, collection: Collection) -> CollectionMetadata:
         hint = (

--- a/src/server/tests/test_api.py
+++ b/src/server/tests/test_api.py
@@ -66,15 +66,15 @@ async def test_search_with_datetime(mock_apis, client):
 
 
 @pytest.mark.anyio
-async def test_search_with_text(mock_apis, client):
-    text = "awesome"
-    response = await client.get("/search", params={"text": text})
+async def test_search_with_q(mock_apis, client):
+    q = "awesome"
+    response = await client.get("/search", params={"q": q})
     assert response.status_code == 200
     json_response = response.json()
     assert len(json_response["results"]) == 2
 
-    text = "appropriate"
-    response = await client.get("/search", params={"text": text})
+    q = "appropriate"
+    response = await client.get("/search", params={"q": q})
     assert response.status_code == 200
     json_response = response.json()
     assert len(json_response["results"]) == 2
@@ -84,9 +84,9 @@ async def test_search_with_text(mock_apis, client):
 async def test_search_with_all_params(mock_apis, client):
     bbox = "10,10,20,20"
     datetime = "2020-01-01T00:00:00Z/2020-01-31T23:59:59Z"
-    text = "awesome"
+    q = "awesome"
     response = await client.get(
-        "/search", params={"bbox": bbox, "datetime": datetime, "text": text}
+        "/search", params={"bbox": bbox, "datetime": datetime, "q": q}
     )
     assert response.status_code == 200
     json_response = response.json()

--- a/src/server/tests/test_collection_search.py
+++ b/src/server/tests/test_collection_search.py
@@ -83,14 +83,14 @@ async def test_stac_api_and_cmr(executor, mock_apis):
             catalogs=[
                 STACAPICollectionSearch(
                     base_url=mock_api_url,
-                    text=text,
+                    q=text,
                 )
                 for mock_api_url in mock_apis
             ]
             + [
                 CMRCollectionSearch(
                     base_url=CMR_OPS,
-                    text=text,
+                    q=text,
                 )
             ],
         )
@@ -109,14 +109,14 @@ async def test_stac_api_and_cmr(executor, mock_apis):
             catalogs=[
                 STACAPICollectionSearch(
                     base_url=mock_api_url,
-                    text=text,
+                    q=text,
                 )
                 for mock_api_url in mock_apis
             ]
             + [
                 CMRCollectionSearch(
                     base_url=CMR_OPS,
-                    text=text,
+                    q=text,
                 )
             ],
         )

--- a/src/server/tests/test_free_text.py
+++ b/src/server/tests/test_free_text.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.free_text import (
+from federated_collection_discovery.free_text import (
     parse_query_for_cmr,
     sqlite_text_search,
 )

--- a/src/server/tests/test_free_text.py
+++ b/src/server/tests/test_free_text.py
@@ -1,0 +1,133 @@
+import pytest
+
+from app.free_text import apply_regex, parse_query_for_cmr, parse_query_for_ogc
+
+
+def test_ogc_single_term():
+    query = "sentinel"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "The sentinel node was true")
+    assert not apply_regex(regex, "No match here")
+
+
+def test_ogc_exact_phrase():
+    query = '"climate model"'
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "The climate model is impressive")
+    assert not apply_regex(regex, "This model is for climate modeling")
+
+    # an exact phrase with a comma inside
+    query = '"models, etc"'
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "Produced with equations, and models, etc.")
+    assert not apply_regex(regex, "Produced with models")
+
+
+def test_ogc_and_terms_default():
+    query = "climate model"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "Climate change is a significant modeling challenge")
+    assert apply_regex(regex, "The model was developed using climate observation data")
+    assert not apply_regex(regex, "This is an advanced model")
+    assert not apply_regex(regex, "No relevant terms here")
+
+
+def test_ogc_or_terms_explicit():
+    query = "climate OR model"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "Climate discussion")
+    assert apply_regex(regex, "FPGA model creation")
+    assert not apply_regex(regex, "No matching term here")
+
+
+def test_ogc_or_terms_commas():
+    query = "climate,model"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "Climate change is here")
+    assert apply_regex(regex, "They built a model train")
+    assert apply_regex(regex, "It's a climate model!")
+    assert not apply_regex(regex, "It's a mathematical equation")
+
+
+def test_ogc_and_terms():
+    query = "climate AND model"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "The climate model is impressive")
+    assert not apply_regex(regex, "This climate change discussion")
+    assert not apply_regex(regex, "Advanced model system")
+
+
+def test_ogc_parentheses_grouping():
+    query = "(quick OR brown) AND fox"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "The quick brown fox")
+    assert apply_regex(regex, "A quick fox jumps")
+    assert apply_regex(regex, "brown bear and a fox")
+    assert not apply_regex(regex, "The fox is clever")
+
+    query = "(quick AND brown) OR (fast AND red)"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "quick brown fox")
+    assert apply_regex(regex, "fast red car")
+    assert not apply_regex(regex, "quick red car")
+
+
+def test_ogc_inclusions_exclusions():
+    query = "quick +brown -fox"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "The quick brown bear")
+    assert not apply_regex(regex, "The quick fox")
+    assert not apply_regex(regex, "The quickest")
+    assert apply_regex(regex, "A quick light brown jumper")
+
+
+def test_ogc_partial_match():
+    query = "climat"
+    regex = parse_query_for_ogc(query)
+    assert apply_regex(regex, "climatology")
+    assert apply_regex(regex, "climate")
+    assert not apply_regex(regex, "climbing")
+
+
+def test_cmr_single_term():
+    query = "climate"
+    cmr_queries = parse_query_for_cmr(query)
+    assert cmr_queries == [query]
+
+
+def test_cmr_comma_or():
+    query = "climate,model,uncertainty"
+    cmr_queries = parse_query_for_cmr(query)
+    assert set(cmr_queries) == set(["climate", "model", "uncertainty"])
+
+
+def test_cmr_parentheses():
+    query = "(quick AND brown) OR (fast AND red)"
+    with pytest.raises(ValueError):
+        parse_query_for_cmr(query)
+    # assert set(cmr_queries) == set(["quick brown", "fast red"])
+
+
+def test_cmr_exact():
+    query = '"climate change","global warming"'
+    cmr_queries = parse_query_for_cmr(query)
+    assert set(cmr_queries) == set(['"climate change"', '"global warming"'])
+
+
+def test_cmr_default_and():
+    query = "climate change model temperature"
+    cmr_queries = parse_query_for_cmr(query)
+    assert cmr_queries == [query]
+
+
+def test_cmr_keyword_and_phrase():
+    query = '"climate model" temperature'
+    cmr_queries = parse_query_for_cmr(query)
+    assert set(cmr_queries) == set(['"climate model"', "temperature"])
+
+
+def test_cmr_and_parentheses():
+    query = "climate AND (warming OR cooling)"
+    with pytest.raises(ValueError):
+        parse_query_for_cmr(query)
+    # assert set(cmr_queries) == set(["climate warming", "climate cooling"])

--- a/src/server/tests/test_stac_api_collection_search.py
+++ b/src/server/tests/test_stac_api_collection_search.py
@@ -55,7 +55,7 @@ def test_text(mock_apis):
     # filter by free-text search
     text_search = STACAPICollectionSearch(
         base_url=mock_apis[0],
-        text="another",
+        q="another",
     )
     assert len(list(text_search.get_collection_metadata())) == 1
 


### PR DESCRIPTION
This approach is slightly heavier than the regex-based approach from #13, but it will more closely resemble the eventual free-text search function in pgstac which will probably use `tsquery`. The regex approach might be a little faster, but the sqlite solution is more robust and much easier to understand because there is existing [documentation](https://www.sqlite.org/fts5.html)!

I like this approach because it resembles [Postgres' text search](https://www.postgresql.org/docs/current/functions-textsearch.html) system which is probably what pgstac will use when we implement the free-text extension functionality there.

resolves #7 