### PR TITLE
improve code hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## 0.1.8
 
-- Nothing
+- add earthaccess and rstac code hints
+
+- surface API errors and warnings in the client app
+
+- validate bounding box input in search form of the client app
+
+- attempt to normalize spatial extents if format is bad
 
 ## 0.1.7
 

--- a/src/client/public/manifest.json
+++ b/src/client/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",

--- a/src/server/federated_collection_discovery/collection_search.py
+++ b/src/server/federated_collection_discovery/collection_search.py
@@ -2,7 +2,7 @@ import itertools
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Iterable, Literal, Optional, Union
+from typing import Iterable, Optional, Union
 
 from federated_collection_discovery.models import (
     CollectionMetadata,
@@ -17,7 +17,6 @@ class CollectionSearch(ABC):
     bbox: Optional[BBox] = None
     datetime: Optional[DatetimeInterval] = None
     q: Optional[str] = None
-    hint_lang: Optional[Literal["python"]] = None
 
     @abstractmethod
     def get_collection_metadata(

--- a/src/server/federated_collection_discovery/hint.py
+++ b/src/server/federated_collection_discovery/hint.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Optional
 
 import black
@@ -5,18 +6,56 @@ from stac_pydantic.shared import BBox
 
 from federated_collection_discovery.shared import DatetimeInterval
 
+
+class Packages(str, Enum):
+    PYSTAC_CLIENT = "pystac-client"
+    PYTHON_CMR = "python-cmr"
+    EARTHACCESS = "earthaccess"
+    RSTAC = "rstac"
+
+
 PYTHON = "python"
-PYSTAC_CLIENT_HINT = """import pystac_client
+PYSTAC_CLIENT_HINT = """# set up an item search with pystac_client
+import pystac_client
 
 catalog = pystac_client.Client.open("{base_url}")
-search = catalog.search(collections="{collection_id}"{remainder})
+
+# get a sample of 10 items
+search = catalog.search(collections="{collection_id}", {other} max_items=10,)
+items = search.items()
 """
 
-CMR_PYTHON_HINT = """from cmr import GranuleQuery
+CMR_PYTHON_HINT = """# set up a granule search with python-cmr
+from cmr import GranuleQuery
 
-search = GranuleQuery(mode="{base_url}").short_name("{short_name}"){remainder}
-granules = search.get()
+# get a sample of 10 granules
+search = GranuleQuery(mode="{base_url}").short_name("{short_name}"){other}
+granules = search.get(10)
 """
+
+EARTHACCESS_HINT = """# set up a granule search with earthaccess
+import earthaccess
+
+earthaccess.login()
+
+# get a sample of 10 granules
+results = earthaccess.search_data(
+    short_name="{short_name}", {other} count=10,
+)
+"""
+
+RSTAC_HINT = """# set up an item search with rstac
+library(rstac)
+
+catalog <- stac("{base_url}")
+
+# get a sample of 10 items
+items <- catalog |>
+  stac_search(
+    collections = "{collection_id}",{other}
+    limit = 10
+  ) |>
+  get_request()"""
 
 
 def generate_pystac_client_hint(
@@ -25,48 +64,124 @@ def generate_pystac_client_hint(
     bbox: Optional[BBox] = None,
     datetime_interval: Optional[DatetimeInterval] = None,
 ) -> str:
-    # Prepare bbox line if bbox is provided, otherwise use an empty string
-    remainder = "," if (bbox or datetime_interval) else ""
+    """Generate a Python snippet for an item search using pystac-client"""
+    other = ""
     if bbox:
-        remainder += f'bbox=({",".join([str(coord) for coord in bbox])}),'
+        other += f'bbox=({",".join([str(coord) for coord in bbox])}),'
 
-    # Prepare datetime line if datetime is provided, otherwise use an empty string
     if datetime_interval:
         datetime_string = "/".join(
             dt.strftime("%Y-%m-%dT%H:%M:%SZ") if dt else ".."  # type: ignore
             for dt in datetime_interval
         )
-        remainder += f'datetime="{datetime_string}",'
+        other += f'datetime="{datetime_string}",'
 
     formatted_hint = PYSTAC_CLIENT_HINT.format(
-        base_url=base_url, collection_id=collection_id, remainder=remainder
+        base_url=base_url, collection_id=collection_id, other=other
     )
+
+    if not other:
+        formatted_hint += (
+            "\n# consider using the bbox and/or datetime filters for a "
+            "more targeted search"
+        )
 
     return black.format_str(formatted_hint, mode=black.FileMode())
 
 
-def generate_cmr_hint(
+def generate_python_cmr_hint(
     base_url: str,
     short_name: str,
     bbox: Optional[BBox] = None,
     datetime_interval: Optional[DatetimeInterval] = None,
-):
-    remainder = ""
+) -> str:
+    """Generate a Python snippet for a granule search using python-cmr"""
+    other = ""
 
     if bbox:
-        remainder += f'.bounding_box({", ".join([str(coord) for coord in bbox])})'
+        other += f'.bounding_box({", ".join([str(coord) for coord in bbox])})'
 
     if datetime_interval:
         datetime_strings = [
             f'"{dt.strftime("%Y-%m-%dT%H:%M:%SZ")}"' if dt else "None"
             for dt in datetime_interval
         ]
-        remainder += f".temporal({','.join(datetime_strings)})"
+        other += f".temporal({','.join(datetime_strings)})"
 
-    formatted_hint = CMR_PYTHON_HINT.format(
+    cmr_hint = CMR_PYTHON_HINT.format(
         base_url=base_url,
         short_name=short_name.strip(),
-        remainder=remainder,
+        other=other,
     )
 
+    if not other:
+        cmr_hint += (
+            "\n# consider applying a bounding box and/or temporal filter for a "
+            "more targeted search"
+        )
+
+    return black.format_str(cmr_hint, mode=black.FileMode())
+
+
+def generate_earthaccess_hint(
+    short_name: str,
+    bbox: Optional[BBox] = None,
+    datetime_interval: Optional[DatetimeInterval] = None,
+) -> str:
+    """Generate a Python snippet for a granule search using earthaccess"""
+
+    other = ""
+
+    if bbox:
+        other += f'bounding_box=({",".join([str(coord) for coord in bbox])}),'
+
+    if datetime_interval:
+        datetime_strings = [
+            f'"{dt.strftime("%Y-%m-%dT%H:%M:%SZ")}"' if dt else "None"
+            for dt in datetime_interval
+        ]
+        other += f"temporal=({','.join(datetime_strings)}),"
+
+    formatted_hint = EARTHACCESS_HINT.format(
+        short_name=short_name.strip(),
+        other=other,
+    )
+
+    if not other:
+        formatted_hint += (
+            "\n# consider using the bounding_box and/or temporal arguments for a "
+            "more targeted search"
+        )
+
     return black.format_str(formatted_hint, mode=black.FileMode())
+
+
+def generate_rstac_hint(
+    base_url: str,
+    collection_id: str,
+    bbox: Optional[BBox] = None,
+    datetime_interval: Optional[DatetimeInterval] = None,
+) -> str:
+    """Generate R snippet for an item search using rstac"""
+    other = ""
+    if bbox:
+        other += f'\n    bbox = c({", ".join([str(coord) for coord in bbox])}),'
+
+    if datetime_interval:
+        datetime_string = "/".join(
+            dt.strftime("%Y-%m-%dT%H:%M:%SZ") if dt else ".."  # type: ignore
+            for dt in datetime_interval
+        )
+        other += f'\n    datetime = "{datetime_string}",'
+
+    formatted_hint = RSTAC_HINT.format(
+        base_url=base_url, collection_id=collection_id, other=other
+    )
+
+    if not other:
+        formatted_hint += (
+            "\n# consider using the bbox and/or datetime args for a more "
+            "targeted search"
+        )
+
+    return formatted_hint

--- a/src/server/federated_collection_discovery/models.py
+++ b/src/server/federated_collection_discovery/models.py
@@ -1,7 +1,9 @@
-from typing import Any, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings
+
+from federated_collection_discovery.hint import Packages
 
 
 class Settings(BaseSettings):  # type: ignore
@@ -28,10 +30,9 @@ class CollectionMetadata(BaseModel):
     title: str
     spatial_extent: Any
     temporal_extent: Any
-    short_name: Optional[str] = None
     description: Optional[str] = None
     keywords: Optional[List[str]] = []
-    hint: Optional[str] = None
+    hint: Optional[Dict[Packages, str]] = None
 
 
 class FederatedSearchError(BaseModel):

--- a/src/server/federated_collection_discovery/stac_api_collection_search.py
+++ b/src/server/federated_collection_discovery/stac_api_collection_search.py
@@ -5,7 +5,11 @@ from pystac_client.client import Client
 from pystac_client.exceptions import APIError
 
 from federated_collection_discovery.collection_search import CollectionSearch
-from federated_collection_discovery.hint import PYTHON, generate_pystac_client_hint
+from federated_collection_discovery.hint import (
+    Packages,
+    generate_pystac_client_hint,
+    generate_rstac_hint,
+)
 from federated_collection_discovery.models import (
     CollectionMetadata,
     FederatedSearchError,
@@ -54,16 +58,20 @@ class STACAPICollectionSearch(CollectionSearch):
             yield FederatedSearchError(catalog_url=self.base_url, error_message=str(e))
 
     def collection_metadata(self, collection: Collection) -> CollectionMetadata:
-        hint = (
-            generate_pystac_client_hint(
+        hint = {
+            Packages.PYSTAC_CLIENT: generate_pystac_client_hint(
                 base_url=self.base_url,
                 collection_id=collection.id,
                 bbox=self.bbox,
                 datetime_interval=self.datetime,
-            )
-            if self.hint_lang == PYTHON
-            else None
-        )
+            ),
+            Packages.RSTAC: generate_rstac_hint(
+                base_url=self.base_url,
+                collection_id=collection.id,
+                bbox=self.bbox,
+                datetime_interval=self.datetime,
+            ),
+        }
 
         extent_dict = collection.extent.to_dict()
 

--- a/src/server/tests/test_hint.py
+++ b/src/server/tests/test_hint.py
@@ -3,21 +3,27 @@ from datetime import datetime
 import black
 
 from federated_collection_discovery.hint import (
-    generate_cmr_hint,
+    generate_earthaccess_hint,
     generate_pystac_client_hint,
+    generate_python_cmr_hint,
+    generate_rstac_hint,
 )
 
 
-def test_cmr_hint_no_params():
-    hint = generate_cmr_hint(
+def test_python_cmr_hint_no_params():
+    hint = generate_python_cmr_hint(
         base_url="https://cmr1.net",
         short_name="dataset-1",
     )
     expected_hint = black.format_str(
         (
+            "# set up a granule search with python-cmr\n"
             "from cmr import GranuleQuery\n\n"
+            "# get a sample of 10 granules\n"
             'search = GranuleQuery(mode="https://cmr1.net").short_name("dataset-1")\n'
-            "granules = search.get()"
+            "granules = search.get(10)\n\n"
+            "# consider applying a bounding box and/or temporal filter for a "
+            "more targeted search"
         ),
         mode=black.FileMode(),
     )
@@ -26,17 +32,19 @@ def test_cmr_hint_no_params():
 
 
 def test_cmr_hint_with_bbox():
-    hint = generate_cmr_hint(
+    hint = generate_python_cmr_hint(
         base_url="https://cmr2.net",
         short_name="dataset-2",
         bbox=(10, 20, 30, 40),
     )
     expected_hint = black.format_str(
         (
+            "# set up a granule search with python-cmr\n"
             "from cmr import GranuleQuery\n\n"
+            "# get a sample of 10 granules\n"
             'search = GranuleQuery(mode="https://cmr2.net").short_name("dataset-2")'
             ".bounding_box(10, 20, 30, 40)\n"
-            "granules = search.get()"
+            "granules = search.get(10)"
         ),
         mode=black.FileMode(),
     )
@@ -45,7 +53,7 @@ def test_cmr_hint_with_bbox():
 
 
 def test_cmr_hint_with_datetime_interval():
-    hint = generate_cmr_hint(
+    hint = generate_python_cmr_hint(
         base_url="https://cmr3.net",
         short_name="dataset-3",
         datetime_interval=(
@@ -55,17 +63,19 @@ def test_cmr_hint_with_datetime_interval():
     )
     expected_hint = black.format_str(
         (
+            "# set up a granule search with python-cmr\n"
             "from cmr import GranuleQuery\n\n"
+            "# get a sample of 10 granules\n"
             'search = GranuleQuery(mode="https://cmr3.net").short_name("dataset-3")'
             '.temporal("2023-01-01T00:00:00Z","2023-12-31T23:59:59Z")\n'
-            "granules = search.get()"
+            "granules = search.get(10)"
         ),
         mode=black.FileMode(),
     )
 
     assert hint.strip() == expected_hint.strip()
 
-    hint = generate_cmr_hint(
+    hint = generate_python_cmr_hint(
         base_url="https://cmr3.net",
         short_name="dataset-3",
         datetime_interval=(
@@ -75,17 +85,19 @@ def test_cmr_hint_with_datetime_interval():
     )
     expected_hint = black.format_str(
         (
+            "# set up a granule search with python-cmr\n"
             "from cmr import GranuleQuery\n\n"
+            "# get a sample of 10 granules\n"
             'search = GranuleQuery(mode="https://cmr3.net").short_name("dataset-3")'
             '.temporal(None,"2023-12-31T23:59:59Z")\n'
-            "granules = search.get()"
+            "granules = search.get(10)"
         ),
         mode=black.FileMode(),
     )
 
     assert hint.strip() == expected_hint.strip()
 
-    hint = generate_cmr_hint(
+    hint = generate_python_cmr_hint(
         base_url="https://cmr3.net",
         short_name="dataset-3",
         datetime_interval=(
@@ -95,10 +107,12 @@ def test_cmr_hint_with_datetime_interval():
     )
     expected_hint = black.format_str(
         (
+            "# set up a granule search with python-cmr\n"
             "from cmr import GranuleQuery\n\n"
+            "# get a sample of 10 granules\n"
             'search = GranuleQuery(mode="https://cmr3.net").short_name("dataset-3")'
             '.temporal("2023-01-01T00:00:00Z",None)\n'
-            "granules = search.get()"
+            "granules = search.get(10)"
         ),
         mode=black.FileMode(),
     )
@@ -106,7 +120,7 @@ def test_cmr_hint_with_datetime_interval():
 
 
 def test_cmr_hint_with_bbox_and_datetime_interval():
-    hint = generate_cmr_hint(
+    hint = generate_python_cmr_hint(
         base_url="https://cmr4.net",
         short_name="dataset-4",
         bbox=(10, 20, 30, 40),
@@ -117,11 +131,13 @@ def test_cmr_hint_with_bbox_and_datetime_interval():
     )
     expected_hint = black.format_str(
         (
+            "# set up a granule search with python-cmr\n"
             "from cmr import GranuleQuery\n\n"
+            "# get a sample of 10 granules\n"
             'search = GranuleQuery(mode="https://cmr4.net").short_name("dataset-4")'
             ".bounding_box(10, 20, 30, 40)"
             '.temporal("2022-06-01T00:00:00Z","2022-06-30T23:59:59Z")\n'
-            "granules = search.get()"
+            "granules = search.get(10)"
         ),
         mode=black.FileMode(),
     )
@@ -136,9 +152,14 @@ def test_pystac_client_hint_no_params():
     )
     expected_hint = black.format_str(
         (
+            "# set up an item search with pystac_client\n"
             "import pystac_client\n\n"
-            'catalog = pystac_client.Client.open("https://stac1.net")\n'
-            'search = catalog.search(collections="collection-1")\n'
+            'catalog = pystac_client.Client.open("https://stac1.net")\n\n'
+            "# get a sample of 10 items\n"
+            'search = catalog.search(collections="collection-1",max_items=10,)\n'
+            "items = search.items()\n\n"
+            "# consider using the bbox and/or datetime filters for a "
+            "more targeted search"
         ),
         mode=black.FileMode(),
     )
@@ -154,10 +175,14 @@ def test_pystac_client_hint_with_bbox():
     )
     expected_hint = black.format_str(
         (
+            "# set up an item search with pystac_client\n"
             "import pystac_client\n\n"
-            'catalog = pystac_client.Client.open("https://stac2.net")\n'
+            'catalog = pystac_client.Client.open("https://stac2.net")\n\n'
+            "# get a sample of 10 items\n"
             'search = catalog.search(collections="collection-2",'
-            "bbox=(10,20,30,40),)\n"
+            "bbox=(10,20,30,40),"
+            "max_items=10,)\n"
+            "items = search.items()"
         ),
         mode=black.FileMode(),
     )
@@ -176,10 +201,14 @@ def test_pystac_client_hint_with_datetime_interval():
     )
     expected_hint = black.format_str(
         (
+            "# set up an item search with pystac_client\n"
             "import pystac_client\n\n"
-            'catalog = pystac_client.Client.open("https://stac3.net")\n'
+            'catalog = pystac_client.Client.open("https://stac3.net")\n\n'
+            "# get a sample of 10 items\n"
             'search = catalog.search(collections="collection-3", '
-            'datetime="2023-01-01T00:00:00Z/2023-12-31T23:59:59Z",)\n'
+            'datetime="2023-01-01T00:00:00Z/2023-12-31T23:59:59Z",'
+            "max_items=10,)\n"
+            "items = search.items()"
         ),
         mode=black.FileMode(),
     )
@@ -199,12 +228,288 @@ def test_pystac_client_hint_with_bbox_and_datetime_interval():
     )
     expected_hint = black.format_str(
         (
+            "# set up an item search with pystac_client\n"
             "import pystac_client\n"
-            'catalog = pystac_client.Client.open("https://stac4.net")\n'
+            'catalog = pystac_client.Client.open("https://stac4.net")\n\n'
+            "# get a sample of 10 items\n"
             "search = catalog.search("
             'collections="collection-4",'
             "bbox=(10,20,30,40),\n"
-            'datetime="2022-06-01T00:00:00Z/2022-06-30T23:59:59Z")\n'
+            'datetime="2022-06-01T00:00:00Z/2022-06-30T23:59:59Z",\n'
+            "max_items=10,)\n"
+            "items = search.items()"
+        ),
+        mode=black.FileMode(),
+    )
+
+    assert hint.strip() == expected_hint.strip()
+
+
+def test_rstac_hint_no_parameters():
+    hint = generate_rstac_hint(
+        base_url="https://stac4.net",
+        collection_id="collection-4",
+    )
+    expected_hint = """# set up an item search with rstac
+library(rstac)
+
+catalog <- stac("https://stac4.net")
+
+# get a sample of 10 items
+items <- catalog |>
+  stac_search(
+    collections = "collection-4",
+    limit = 10
+  ) |>
+  get_request()
+# consider using the bbox and/or datetime args for a more targeted search
+"""
+
+    assert hint.strip() == expected_hint.strip()
+
+
+def test_rstac_hint_bbox():
+    hint = generate_rstac_hint(
+        base_url="https://stac4.net",
+        collection_id="collection-4",
+        bbox=(1, 2, 3, 4),
+    )
+    expected_hint = """# set up an item search with rstac
+library(rstac)
+
+catalog <- stac("https://stac4.net")
+
+# get a sample of 10 items
+items <- catalog |>
+  stac_search(
+    collections = "collection-4",
+    bbox = c(1, 2, 3, 4),
+    limit = 10
+  ) |>
+  get_request()"""
+
+    assert hint.strip() == expected_hint.strip()
+
+
+def test_rstac_hint_datetime():
+    hint = generate_rstac_hint(
+        base_url="https://stac4.net",
+        collection_id="collection-4",
+        datetime_interval=(datetime(2024, 1, 1), datetime(2024, 2, 1)),
+    )
+    expected_hint = """# set up an item search with rstac
+library(rstac)
+
+catalog <- stac("https://stac4.net")
+
+# get a sample of 10 items
+items <- catalog |>
+  stac_search(
+    collections = "collection-4",
+    datetime = "2024-01-01T00:00:00Z/2024-02-01T00:00:00Z",
+    limit = 10
+  ) |>
+  get_request()"""
+
+    assert hint.strip() == expected_hint.strip()
+
+    # open interval (no end)
+    hint = generate_rstac_hint(
+        base_url="https://stac4.net",
+        collection_id="collection-4",
+        datetime_interval=(datetime(2024, 1, 1), None),
+    )
+    expected_hint = """# set up an item search with rstac
+library(rstac)
+
+catalog <- stac("https://stac4.net")
+
+# get a sample of 10 items
+items <- catalog |>
+  stac_search(
+    collections = "collection-4",
+    datetime = "2024-01-01T00:00:00Z/..",
+    limit = 10
+  ) |>
+  get_request()"""
+
+    assert hint.strip() == expected_hint.strip()
+
+    # open interval (no start)
+    hint = generate_rstac_hint(
+        base_url="https://stac4.net",
+        collection_id="collection-4",
+        datetime_interval=(None, datetime(2024, 1, 1)),
+    )
+    expected_hint = """# set up an item search with rstac
+library(rstac)
+
+catalog <- stac("https://stac4.net")
+
+# get a sample of 10 items
+items <- catalog |>
+  stac_search(
+    collections = "collection-4",
+    datetime = "../2024-01-01T00:00:00Z",
+    limit = 10
+  ) |>
+  get_request()"""
+
+    assert hint.strip() == expected_hint.strip()
+
+
+def test_rstac_hint_bbox_and_datetime():
+    hint = generate_rstac_hint(
+        base_url="https://stac4.net",
+        collection_id="collection-4",
+        bbox=(1, 2, 3, 4),
+        datetime_interval=(datetime(2024, 1, 1), datetime(2024, 2, 1)),
+    )
+    expected_hint = """# set up an item search with rstac
+library(rstac)
+
+catalog <- stac("https://stac4.net")
+
+# get a sample of 10 items
+items <- catalog |>
+  stac_search(
+    collections = "collection-4",
+    bbox = c(1, 2, 3, 4),
+    datetime = "2024-01-01T00:00:00Z/2024-02-01T00:00:00Z",
+    limit = 10
+  ) |>
+  get_request()"""
+
+    assert hint.strip() == expected_hint.strip()
+
+
+def test_earthaccess_hint_no_params():
+    hint = generate_earthaccess_hint(
+        short_name="dataset-1",
+    )
+    expected_hint = black.format_str(
+        (
+            "# set up a granule search with earthaccess\n"
+            "import earthaccess\n\n"
+            "earthaccess.login()\n\n"
+            "# get a sample of 10 granules\n"
+            'results = earthaccess.search_data(short_name="dataset-1",count=10,)\n\n'
+            "# consider using the bounding_box and/or temporal arguments for a "
+            "more targeted search"
+        ),
+        mode=black.FileMode(),
+    )
+
+    assert hint.strip() == expected_hint.strip()
+
+
+def test_earthaccess_hint_with_bbox():
+    hint = generate_earthaccess_hint(
+        short_name="dataset-1",
+        bbox=(10, 20, 30, 40),
+    )
+    expected_hint = black.format_str(
+        (
+            "# set up a granule search with earthaccess\n"
+            "import earthaccess\n\n"
+            "earthaccess.login()\n\n"
+            "# get a sample of 10 granules\n"
+            'results = earthaccess.search_data(short_name="dataset-1",'
+            "bounding_box=(10, 20, 30, 40),"
+            "count=10,)"
+        ),
+        mode=black.FileMode(),
+    )
+
+    assert hint.strip() == expected_hint.strip()
+
+
+def test_earthaccess_hint_with_datetime_interval():
+    hint = generate_earthaccess_hint(
+        short_name="dataset-1",
+        datetime_interval=(
+            datetime(2023, 1, 1, 0, 0, 0),
+            datetime(2023, 12, 31, 23, 59, 59),
+        ),
+    )
+    expected_hint = black.format_str(
+        (
+            "# set up a granule search with earthaccess\n"
+            "import earthaccess\n\n"
+            "earthaccess.login()\n\n"
+            "# get a sample of 10 granules\n"
+            'results = earthaccess.search_data(short_name="dataset-1",'
+            'temporal=("2023-01-01T00:00:00Z","2023-12-31T23:59:59Z"),'
+            "count=10,)"
+        ),
+        mode=black.FileMode(),
+    )
+
+    assert hint.strip() == expected_hint.strip()
+
+    hint = generate_earthaccess_hint(
+        short_name="dataset-1",
+        datetime_interval=(
+            None,
+            datetime(2023, 12, 31, 23, 59, 59),
+        ),
+    )
+    expected_hint = black.format_str(
+        (
+            "# set up a granule search with earthaccess\n"
+            "import earthaccess\n\n"
+            "earthaccess.login()\n\n"
+            "# get a sample of 10 granules\n"
+            'results = earthaccess.search_data(short_name="dataset-1",'
+            'temporal=(None, "2023-12-31T23:59:59Z"),'
+            "count=10,)"
+        ),
+        mode=black.FileMode(),
+    )
+
+    assert hint.strip() == expected_hint.strip()
+
+    hint = generate_earthaccess_hint(
+        short_name="dataset-1",
+        datetime_interval=(
+            datetime(2023, 1, 1, 0, 0, 0),
+            None,
+        ),
+    )
+    expected_hint = black.format_str(
+        (
+            "# set up a granule search with earthaccess\n"
+            "import earthaccess\n\n"
+            "earthaccess.login()\n\n"
+            "# get a sample of 10 granules\n"
+            'results = earthaccess.search_data(short_name="dataset-1",'
+            'temporal=("2023-01-01T00:00:00Z",None),'
+            "count=10,)"
+        ),
+        mode=black.FileMode(),
+    )
+    assert hint.strip() == expected_hint.strip()
+
+
+def test_earthaccess_hint_with_bbox_and_datetime_interval():
+    hint = generate_earthaccess_hint(
+        short_name="dataset-1",
+        bbox=(10, 20, 30, 40),
+        datetime_interval=(
+            datetime(2022, 6, 1, 0, 0, 0),
+            datetime(2022, 6, 30, 23, 59, 59),
+        ),
+    )
+    expected_hint = black.format_str(
+        (
+            "# set up a granule search with earthaccess\n"
+            "import earthaccess\n\n"
+            "earthaccess.login()\n\n"
+            "# get a sample of 10 granules\n"
+            'results = earthaccess.search_data(short_name="dataset-1",'
+            "bounding_box=(10,20,30,40),"
+            'temporal=("2022-06-01T00:00:00Z","2022-06-30T23:59:59Z"),'
+            "count=10,)"
         ),
         mode=black.FileMode(),
     )


### PR DESCRIPTION
It turns out the CMR STAC collection ID is just `{short_name}_{version_id}` from the CMR collection search result. This PR adds a `pystac_client` search hint to the `python-cmr` search hint for CMR results and adds a tabbed interface for the hints in the client app.

Resolves https://github.com/NASA-IMPACT/active-maap-sprint/issues/1045
Resolves #30 