### PR TITLE
feat: handle upstream api failures reported via X-Failed-Upstream-Apis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,3 +380,6 @@ Temporary Items
 
 .envrc
 MIGRATION_PLAN.md
+
+# implementation plans
+dev-docs/plans/

--- a/dev-docs/specs/surface-upstream-api-failures.md
+++ b/dev-docs/specs/surface-upstream-api-failures.md
@@ -1,0 +1,383 @@
+# Spec: Surface Upstream API Failures in the Frontend
+
+## Context
+
+The `stac-fastapi-collection-discovery` backend is gaining graceful upstream API
+failure handling (see
+[PR #13](https://github.com/developmentseed/stac-fastapi-collection-discovery/pull/13)).
+When one or more upstream STAC APIs fail during a collection search, the
+backend no longer aborts the entire request. Instead it:
+
+- Logs the failure
+- Omits the failed API's results from the response
+- Returns the remaining results with HTTP 200
+- Adds a `X-Failed-Upstream-Apis` response header containing a
+  comma-separated list of failed API URLs
+
+This federated collection discovery frontend currently has no knowledge of this
+header. Users may see fewer results than expected with no explanation when an
+upstream API is down. This spec describes the minimal frontend changes needed
+to read the new header and inform users when partial failures occur.
+
+## Goals
+
+- **Primary:** Read the `X-Failed-Upstream-Apis` header after every search
+  and "load more" request and surface the information to the user.
+- **Secondary:** Display a non-blocking warning that clearly states which
+  upstream APIs failed and that results may be incomplete.
+- **Tertiary:** Integrate runtime failure information into the API
+  Configuration indicator and Diagnostics tab so that an API which passes
+  the health check but failed during search is shown with a degraded
+  (yellow/amber) status rather than a purely healthy (green) one.
+- **Quaternary:** Keep the existing search/pagination UX unchanged; this is
+  an additive, non-breaking enhancement.
+
+## Non-Goals
+
+- Implement automatic retries for failed APIs (out of scope; the backend
+  drops them from pagination tokens).
+- Add a "strict mode" toggle to the frontend UI. The frontend will rely on
+  the backend default (`strict=false`) and treat partial failures as
+  informational warnings.
+- Modify how the backend handles failures.
+- Add per-API success/failure metrics or telemetry in the UI.
+
+## Constraints & Assumptions
+
+- The `fetch` API exposes response headers. `X-Failed-Upstream-Apis` will be
+  accessible via `response.headers.get("X-Failed-Upstream-Apis")` provided
+  the backend CORS configuration exposes the custom header.
+- The header is **absent** when all APIs succeed. It is **present** when at
+  least one failed.
+- Failed APIs are dropped from pagination tokens. Once an API fails on page 1,
+  it will not be queried on page 2. The warning should therefore appear only
+  on pages where failures actually occurred.
+- The existing alert/warning UI components (`Alert`, `AlertDescription` from
+  `@/components/ui/alert`) are sufficient for displaying the warning.
+- The application is a React SPA using `fetch`. No changes to build tooling,
+  routing, or state management library are needed.
+
+## Architecture Overview
+
+The change touches four layers:
+
+1. **API Layer** (`src/api/search.ts`): Update `searchApi` and `fetchNextPage`
+   to return both the parsed JSON body and a list of failed upstream API URLs
+   extracted from the response header.
+2. **App State** (`src/App.tsx`): Track `failedApis: string[]` alongside
+   existing `results`, `apiError`, and `nextPageUrl` state. Clear the list on
+   every new search, append to it on "load more".
+3. **Results UI** (`src/components/ResultsTable.tsx`): Render a non-blocking
+   warning banner above the results when `failedApis` is non-empty.
+4. **Configuration UI** (`src/components/ApiConfigPanel.tsx`): Accept
+   `failedApis` as a prop and combine it with static health-check data
+   to compute a combined status. An API that is `healthy: true` in the
+   health endpoint but appears in `failedApis` is rendered with a
+   yellow/amber degraded indicator.
+
+```
++-------------+     +------------------+     +------------------+
+| User clicks |---->| searchApi /      |---->| Fetch response   |
+| "Search"    |     | fetchNextPage    |     | + check header   |
++-------------+     +------------------+     +------------------+
+                                                        |
+                                                        v
++----------------+  +------------------+     +------------------+
+| ResultsTable   |<-| App ()           |<----| { collections,   |
+| (failedApis)   |  | setFailedApis    |     |   failedApis }   |
++----------------+  +------------------+     +------------------+
+       ^
+       |
++----------------+  +------------------+
+| ApiConfigPanel |<-| failedApis prop  |
+| (combined      |  +------------------+
+|  status)       |
++----------------+
+```
+
+## API / Interface Design
+
+### Updated Search Response
+
+```typescript
+// src/api/search.ts
+export interface SearchResponse {
+  collections: any[];
+  links: any[];
+}
+
+export interface SearchResult {
+  data: SearchResponse;
+  failedApis: string[];
+}
+```
+
+### Updated API Functions
+
+```typescript
+export async function searchApi(
+  params: SearchParams,
+  stacApis?: string[]
+): Promise<SearchResult>;
+
+export async function fetchNextPage(nextUrl: string): Promise<SearchResult>;
+```
+
+### Header Parsing Helper
+
+```typescript
+function parseFailedApis(response: Response): string[] {
+  const header = response.headers.get("X-Failed-Upstream-Apis");
+  if (!header) return [];
+  return header
+    .split(",")
+    .map((url) => url.trim())
+    .filter(Boolean);
+}
+```
+
+### App State Extension
+
+```typescript
+const [failedApis, setFailedApis] = React.useState<string[]>([]);
+```
+
+Passed into `ResultsTable`:
+
+```typescript
+interface Props {
+  data: Array<Record<string, any>>;
+  hasNextPage?: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore?: () => void;
+  hasSearched?: boolean;
+  stacApis?: string[];
+  failedApis?: string[];
+}
+```
+
+Passed into `ApiConfigPanel`:
+
+```typescript
+interface ApiConfigPanelProps {
+  stacApis: string[];
+  onUpdate: (apis: string[]) => void;
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  failedApis?: string[]; // NEW: runtime failures from search
+}
+```
+
+## Data Model
+
+No external data model changes. The only new shape is an internal TypeScript
+interface:
+
+```typescript
+interface SearchResult {
+  data: SearchResponse;
+  failedApis: string[];
+}
+```
+
+The `failedApis` field is a flat array of URL strings, deduplicated if
+"load more" encounters additional failures.
+
+## Integration Points
+
+### 1. `src/api/search.ts`
+
+Both `searchApi` and `fetchNextPage` currently do:
+
+```typescript
+const data = await response.json();
+return applyApiFilters(data);
+```
+
+They will be updated to:
+
+```typescript
+const data = await response.json();
+const failedApis = parseFailedApis(response);
+return {
+  data: applyApiFilters(data),
+  failedApis,
+};
+```
+
+**CORS Consideration:** For `fetch` to read `X-Failed-Upstream-Apis`, the
+backend must include it in `Access-Control-Expose-Headers`. The backend PR
+updates CORS middleware via `allow_headers=["*"]`, which in starlette usually
+only affects _request_ headers. We should confirm that the backend also exposes
+the header in the CORS preflight response. If not, the frontend will see the
+header as `null`. A note should be added to the spec or implementation docs.
+
+### 2. `src/App.tsx`
+
+**State:**
+
+```typescript
+const [failedApis, setFailedApis] = React.useState<string[]>([]);
+```
+
+**`handleSearch`:**
+
+```typescript
+const { data, failedApis } = await searchApi(formData, stacApis);
+setResults(data.collections);
+setFailedApis(failedApis);
+```
+
+**`handleLoadMore`:**
+
+```typescript
+const { data, failedApis } = await fetchNextPage(nextPageUrl);
+setResults((prev) => [...prev, ...data.collections]);
+setFailedApis((prev) => [...new Set([...prev, ...failedApis])]);
+```
+
+**UI:** Insert an `Alert` variant (e.g., `variant="default"` with an
+informational tone) in `SearchPanelContent` or `ResultsTable` when
+`failedApis.length > 0`.
+
+### 3. `src/components/ApiConfigPanel.tsx`
+
+**Combined health logic:**
+
+The existing `getOverallStatus()` function computes status from the backend
+`/health` endpoint and conformance checks. It should now also accept the
+`failedApis` prop and downgrade the overall status when any currently-enabled
+API appears in the failure list:
+
+- If `healthData.status === "UP"` but one or more enabled APIs are in
+  `failedApis`, the sidebar indicator should show **yellow/amber** with
+  status text `"Degraded"` instead of `"Healthy"`.
+- If `healthData.status === "UP"` and no enabled APIs are in `failedApis`,
+  the indicator remains `"Healthy"` (green).
+- If `healthData.status !== "UP"` or APIs lack collection search, the
+  existing red/orange logic takes precedence.
+
+**Per-API diagnostics:**
+
+In the Diagnostics tab, each upstream API card already shows a colored dot
+based on `api.healthy`. When `failedApis.includes(url)` for a given API,
+override the dot color to yellow/amber and append a tooltip or badge
+explaining: "This API responded to the health check but failed during the
+most recent search. Results may be incomplete."
+
+```tsx
+const isRuntimeFailed = failedApis?.includes(url) ?? false;
+const dotColor =
+  api.healthy && !isRuntimeFailed
+    ? "rgb(34 197 94)" // green
+    : isRuntimeFailed
+      ? "rgb(234 179 8)" // amber-500
+      : "rgb(239 68 68)"; // red
+```
+
+### 4. `src/components/ResultsTable.tsx`
+
+Receive `failedApis` via props. Render a compact banner above the table/card
+grid:
+
+```tsx
+{
+  failedApis && failedApis.length > 0 && (
+    <Alert className="mb-4">
+      <AlertCircle className="h-4 w-4" />
+      <AlertDescription>
+        Some upstream APIs failed and were excluded from results:
+        <ul className="mt-1 list-disc list-inside text-sm">
+          {failedApis.map((url) => (
+            <li key={url} className="break-all">
+              {url}
+            </li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
+  );
+}
+```
+
+This is additive and does not replace or affect the existing `apiError` alert
+(which is for blocking 4xx/5xx errors on the discovery API itself).
+
+## Migration Path
+
+No migration needed. This is an additive feature. Existing behavior is
+unchanged when the header is absent (all upstream APIs healthy).
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Header present:** Mock `fetch` returning `200` with
+   `X-Failed-Upstream-Apis: https://api1.example.com`. Assert
+   `searchApi` returns `failedApis` containing the URL.
+2. **Header absent:** Mock `fetch` returning `200` without the header.
+   Assert `failedApis` is an empty array.
+3. **Header with multiple APIs:** Mock `fetch` with a comma-separated list.
+   Assert all URLs are parsed and trimmed.
+4. **Error path unchanged:** Mock `fetch` returning `500`. Assert the
+   function still throws (this is a backend-level failure, not an upstream
+   API failure).
+
+### Component Tests
+
+1. **Render with failures:** Pass `failedApis` to `ResultsTable`. Assert the
+   alert banner renders with the URLs.
+2. **Render without failures:** Pass empty `failedApis`. Assert no banner.
+3. **App integration:** In `App`, trigger `handleSearch` with a mocked
+   `searchApi` that returns failures. Assert `failedApis` state is set and
+   the banner appears.
+
+### End-to-End / Manual Testing
+
+1. Configure an upstream API that returns a 500 (or temporarily block one
+   via `/etc/hosts`). Perform a search. Verify the banner appears with the
+   blocked URL and that results still load from healthy APIs.
+2. Click "Load More" when a failure occurred on the first page. Verify the
+   banner persists (or is re-displayed if new failures occur).
+
+## Decision Log
+
+| Decision                                                              | Options Considered                                              | Rationale                                                                                                                                                                                                                                                                |
+| --------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Pass `failedApis` as prop to `ResultsTable` vs keep entirely in `App` | Keep in `App` only, render in `SearchPanelContent`              | `ResultsTable` owns the results display area; placing the warning there keeps spatial context with the data it describes.                                                                                                                                                |
+| Show banner in `SearchPanelContent` vs `ResultsTable`                 | Sidebar alert, banner above table                               | `ResultsTable` is the natural place because the warning is directly about the displayed results, not the search form.                                                                                                                                                    |
+| Dedupe `failedApis` on "load more"                                    | Always replace, always append                                   | Deduplicating via `new Set` is robust and handles edge cases where the same API fails across pages.                                                                                                                                                                      |
+| Do not add a `strict` mode toggle                                     | Add a toggle in UI                                              | The backend default is `strict=false`, which is the desired user experience (show results + warn). Adding a toggle adds UI complexity for a niche debugging use case. Can be added later if needed.                                                                      |
+| Use existing `Alert` component vs custom banner                       | Custom styled banner                                            | The existing `Alert` with default styling is sufficient and keeps the UI consistent.                                                                                                                                                                                     |
+| Warn in sidebar vs results area                                       | Sidebar alert                                                   | The sidebar is already dense with configuration and search controls. The results area is where the user looks after performing a search.                                                                                                                                 |
+| **Combine health-check and runtime failure status**                   | Show them separately, only show banner, ignore runtime failures | Health checks are point-in-time and can be stale. If an API passes the health check but fails during search, showing only a green dot is misleading. A combined yellow/amber state makes the discrepancy visible without requiring the user to open the diagnostics tab. |
+| **Apply combined status per-API in diagnostics**                      | Show separate "health" and "search failure" columns             | A single combined indicator per API keeps the diagnostics UI compact. The yellow dot naturally signals "something is wrong with this API" and can be supplemented with a tooltip or badge explaining the nature of the degradation.                                      |
+
+## Open Questions
+
+1. **Banner persistence:** Should the user be able to dismiss the warning
+   banner per session, or should it always be visible when failures exist?
+2. **Auto-refresh health checks:** When `failedApis` changes, should the
+   frontend automatically re-trigger the `/health` endpoint to get the latest
+   static health status? Or should it rely solely on the existing health data
+   plus runtime failures?
+3. **Failure history:** Should `failedApis` be persisted across page reloads
+   (e.g., in session storage) so that the degraded API indicator remains
+   visible after a refresh, or should it always be cleared on every new search?
+4. **Clearing `failedApis`:** Should clearing `failedApis` (e.g., via a
+   "Retry" or "Reset" action) also trigger a new search to verify the API
+   has recovered, or should it be purely a UI reset?
+
+## Status
+
+- [x] Designing
+- [x] Approved — ready to plan
+- [x] Implementing
+- [x] Implemented — undergoing revision to combine health-check and runtime-failure signals
+
+## References
+
+- Backend PR:
+  [developmentseed/stac-fastapi-collection-discovery#13](https://github.com/developmentseed/stac-fastapi-collection-discovery/pull/13)
+- Backend spec:
+  `dev-docs/specs/upstream-error-handling.md` (in backend repo)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-stac-fastapi-collection-discovery = { git = "https://github.com/developmentseed/stac-fastapi-collection-discovery", rev = "v0.2.3" }
+stac-fastapi-collection-discovery = { git = "https://github.com/developmentseed/stac-fastapi-collection-discovery", rev = "v0.3.0" }
 
 [dependency-groups]
 dev = [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ export const App = () => {
   const [loading, setLoading] = React.useState<boolean>(false);
   const [loadingMore, setLoadingMore] = React.useState<boolean>(false);
   const [apiError, setApiError] = React.useState<ApiError>(null); // For 400/500 errors
+  const [failedApis, setFailedApis] = React.useState<string[]>([]);
   const [nextPageUrl, setNextPageUrl] = React.useState<string | null>(null);
   const [hasSearched, setHasSearched] = React.useState<boolean>(false);
   const hasRunInitialSearch = React.useRef(false);
@@ -138,15 +139,22 @@ export const App = () => {
     setLoading(true);
     setApiError(null);
     setResults([]);
+    setFailedApis([]);
     setIsSearchSheetOpen(false); // Close mobile sheet after search
 
     try {
-      const data = await searchApi(formData, stacApis);
-      setResults(data.collections);
+      const { data: searchData, failedApis: failures } = await searchApi(
+        formData,
+        stacApis
+      );
+      setResults(searchData.collections);
+      setFailedApis(failures);
       setHasSearched(true);
 
       // Extract next page URL from links
-      const nextLink = data.links?.find((link: any) => link.rel === "next");
+      const nextLink = searchData.links?.find(
+        (link: any) => link.rel === "next"
+      );
       setNextPageUrl(nextLink?.href || null);
     } catch (error) {
       console.error("Search error:", error);
@@ -166,13 +174,15 @@ export const App = () => {
     setApiError(null);
 
     try {
-      const data = await fetchNextPage(nextPageUrl);
+      const { data: pageData, failedApis: failures } =
+        await fetchNextPage(nextPageUrl);
 
       // Append new results to existing ones
-      setResults((prevResults) => [...prevResults, ...data.collections]);
+      setResults((prevResults) => [...prevResults, ...pageData.collections]);
+      setFailedApis((prev) => [...new Set([...prev, ...failures])]);
 
       // Update next page URL for potential further pagination
-      const nextLink = data.links?.find((link: any) => link.rel === "next");
+      const nextLink = pageData.links?.find((link: any) => link.rel === "next");
       setNextPageUrl(nextLink?.href || null);
     } catch (error) {
       console.error("Load more error:", error);
@@ -270,6 +280,7 @@ export const App = () => {
             onUpdate={handleUpdateStacApis}
             isOpen={isApiConfigOpen}
             onOpenChange={setIsApiConfigOpen}
+            failedApis={failedApis}
           />
         </React.Suspense>
       </div>
@@ -407,6 +418,7 @@ export const App = () => {
                   isLoadingMore={loadingMore}
                   onLoadMore={handleLoadMore}
                   hasSearched={hasSearched}
+                  failedApis={failedApis}
                   stacApis={stacApis}
                 />
               </div>

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -142,10 +142,24 @@ type SearchResponse = {
   links: any[];
 };
 
+export interface SearchResult {
+  data: SearchResponse;
+  failedApis: string[];
+}
+
+function parseFailedApis(response: Response): string[] {
+  const header = response.headers.get("X-Failed-Upstream-Apis");
+  if (!header) return [];
+  return header
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
 export async function searchApi(
   params: SearchParams,
   stacApis?: string[]
-): Promise<SearchResponse> {
+): Promise<SearchResult> {
   console.log(`${params.datetime}`);
   const queryString = buildQuery(params, stacApis);
   const url = `${API_URL}/collections?${queryString}`;
@@ -159,6 +173,7 @@ export async function searchApi(
     });
 
     const data = await response.json();
+    const failedApis = parseFailedApis(response);
 
     if (!response.ok) {
       // Handle API-level errors (400/500)
@@ -168,14 +183,14 @@ export async function searchApi(
       );
     }
 
-    return applyApiFilters(data);
+    return { data: applyApiFilters(data), failedApis };
   } catch (error) {
     console.error("Error encountered while performing search:", error);
     throw error;
   }
 }
 
-export async function fetchNextPage(nextUrl: string): Promise<SearchResponse> {
+export async function fetchNextPage(nextUrl: string): Promise<SearchResult> {
   try {
     const response = await fetch(nextUrl, {
       method: "GET",
@@ -185,6 +200,7 @@ export async function fetchNextPage(nextUrl: string): Promise<SearchResponse> {
     });
 
     const data = await response.json();
+    const failedApis = parseFailedApis(response);
 
     if (!response.ok) {
       throw new Error(
@@ -193,7 +209,7 @@ export async function fetchNextPage(nextUrl: string): Promise<SearchResponse> {
       );
     }
 
-    return applyApiFilters(data);
+    return { data: applyApiFilters(data), failedApis };
   } catch (error) {
     console.error("Error encountered while fetching next page:", error);
     throw error;

--- a/src/components/ApiConfigPanel.tsx
+++ b/src/components/ApiConfigPanel.tsx
@@ -58,6 +58,7 @@ interface ApiConfigPanelProps {
   onUpdate: (apis: string[]) => void;
   isOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  failedApis?: string[];
 }
 
 const ApiConfigPanel: React.FC<ApiConfigPanelProps> = ({
@@ -65,6 +66,7 @@ const ApiConfigPanel: React.FC<ApiConfigPanelProps> = ({
   onUpdate,
   isOpen: controlledIsOpen,
   onOpenChange: controlledOnOpenChange,
+  failedApis = [],
 }) => {
   // Use internal state if not controlled from parent
   const [internalIsOpen, setInternalIsOpen] = useState(false);
@@ -204,6 +206,17 @@ const ApiConfigPanel: React.FC<ApiConfigPanelProps> = ({
       return {
         color: "orange",
         status: "Limited",
+        isLoading: false,
+        hasIssues: true,
+      };
+    }
+
+    const hasRuntimeFailures = stacApis.some((api) => failedApis.includes(api));
+
+    if (hasRuntimeFailures) {
+      return {
+        color: "amber",
+        status: "Degraded",
         isLoading: false,
         hasIssues: true,
       };
@@ -366,9 +379,11 @@ const ApiConfigPanel: React.FC<ApiConfigPanelProps> = ({
                   ? "rgb(34 197 94)"
                   : color === "orange"
                     ? "rgb(249 115 22)"
-                    : color === "red"
-                      ? "rgb(239 68 68)"
-                      : "rgb(107 114 128)",
+                    : color === "amber"
+                      ? "rgb(234 179 8)"
+                      : color === "red"
+                        ? "rgb(239 68 68)"
+                        : "rgb(107 114 128)",
             }}
           />
         )}
@@ -613,9 +628,13 @@ const ApiConfigPanel: React.FC<ApiConfigPanelProps> = ({
                             className="w-2.5 h-2.5 sm:w-3 sm:h-3 rounded-full shrink-0"
                             style={{
                               backgroundColor:
-                                healthData.status === "UP"
+                                color === "green"
                                   ? "rgb(34 197 94)"
-                                  : "rgb(239 68 68)",
+                                  : color === "amber"
+                                    ? "rgb(234 179 8)"
+                                    : color === "orange"
+                                      ? "rgb(249 115 22)"
+                                      : "rgb(239 68 68)",
                             }}
                           />
                           <span className="font-semibold text-sm sm:text-base">
@@ -623,13 +642,19 @@ const ApiConfigPanel: React.FC<ApiConfigPanelProps> = ({
                           </span>
                           <Badge
                             variant={
-                              healthData.status === "UP"
-                                ? "default"
-                                : "destructive"
+                              color === "red"
+                                ? "destructive"
+                                : color === "amber"
+                                  ? "outline"
+                                  : "default"
                             }
-                            className="ml-auto text-xs"
+                            className={cn(
+                              "ml-auto text-xs",
+                              color === "amber" &&
+                                "border-amber-400 text-amber-700 dark:text-amber-400"
+                            )}
                           >
-                            {healthData.status}
+                            {status}
                           </Badge>
                         </div>
                       </CardContent>
@@ -646,6 +671,8 @@ const ApiConfigPanel: React.FC<ApiConfigPanelProps> = ({
                           const hasCollectionSearch =
                             hasCollectionSearchSupport(conformance);
                           const hasFreeText = hasFreeTextSupport(conformance);
+                          const isRuntimeFailed =
+                            failedApis?.includes(url) ?? false;
 
                           return (
                             <Card key={url}>
@@ -659,14 +686,25 @@ const ApiConfigPanel: React.FC<ApiConfigPanelProps> = ({
                                   <div
                                     className="w-2 h-2 sm:w-2.5 sm:h-2.5 rounded-full shrink-0"
                                     style={{
-                                      backgroundColor: api.healthy
-                                        ? "rgb(34 197 94)"
-                                        : "rgb(239 68 68)",
+                                      backgroundColor:
+                                        api.healthy && !isRuntimeFailed
+                                          ? "rgb(34 197 94)"
+                                          : isRuntimeFailed
+                                            ? "rgb(234 179 8)"
+                                            : "rgb(239 68 68)",
                                     }}
                                   />
                                   <span className="text-xs sm:text-sm font-medium break-all">
                                     {url}
                                   </span>
+                                  {isRuntimeFailed && (
+                                    <Badge
+                                      variant="outline"
+                                      className="text-[10px] sm:text-xs border-amber-400 text-amber-600 dark:text-amber-400 shrink-0"
+                                    >
+                                      Degraded
+                                    </Badge>
+                                  )}
                                 </div>
 
                                 <div
@@ -710,6 +748,21 @@ const ApiConfigPanel: React.FC<ApiConfigPanelProps> = ({
                                     </span>{" "}
                                     {conformance.join(", ")}
                                   </p>
+                                )}
+
+                                {isRuntimeFailed && (
+                                  <Alert className="border-amber-200 dark:border-amber-800 py-2">
+                                    <AlertDescription className="text-[10px] sm:text-xs text-amber-600 dark:text-amber-400">
+                                      <p className="font-medium mb-1">
+                                        Degraded during most recent search
+                                      </p>
+                                      <p>
+                                        This API responded to the health check
+                                        but failed during the most recent
+                                        search. Results may be incomplete.
+                                      </p>
+                                    </AlertDescription>
+                                  </Alert>
                                 )}
                               </CardContent>
                             </Card>

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -33,7 +33,8 @@ import { transformExtent } from "ol/proj";
 import "ol/ol.css";
 import "ol-layerswitcher/dist/ol-layerswitcher.css";
 import ReactMarkdown from "react-markdown";
-import { ChevronDown, Loader2 } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { ChevronDown, Loader2, AlertCircle } from "lucide-react";
 import { cn } from "@/utils/utils";
 import { stack, hstack, touchTarget, dialog } from "@/utils/responsive";
 import { useDarkMode } from "@/utils/hooks";
@@ -186,6 +187,7 @@ interface Props {
   isLoadingMore?: boolean;
   onLoadMore?: () => void;
   hasSearched?: boolean;
+  failedApis?: string[];
   stacApis?: string[];
 }
 
@@ -249,6 +251,7 @@ const ResultsTable: React.FC<Props> = ({
   isLoadingMore = false,
   onLoadMore,
   hasSearched = false,
+  failedApis = [],
   stacApis = [],
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -421,6 +424,22 @@ const ResultsTable: React.FC<Props> = ({
   return (
     <>
       <div className="overflow-auto max-h-full">
+        {failedApis.length > 0 && (
+          <Alert className="m-4" variant="default">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              The following API{failedApis.length > 1 ? "s" : ""} did not
+              respond and results may be incomplete:
+              <ul className="mt-1 list-disc list-inside">
+                {failedApis.map((api) => (
+                  <li key={api} className="break-all">
+                    {api}
+                  </li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
         {isMobile ? (
           <MobileCardView />
         ) : data.length === 0 ? (


### PR DESCRIPTION
Before this change, any failure in any upstream API would cause the entire search to fail. Paried with https://github.com/developmentseed/stac-fastapi-collection-discovery/pull/13 this PR allows those failures to be tracked but not block the search results.

This is what the warning looks like:
<img width="2505" height="1249" alt="image" src="https://github.com/user-attachments/assets/448b1014-b69d-41c2-b673-9dd2ce50297a" />


Resolves #182
